### PR TITLE
fix: loading for new inbox, update url params  #52

### DIFF
--- a/src/components/agent-inbox/contexts/ThreadContext.tsx
+++ b/src/components/agent-inbox/contexts/ThreadContext.tsx
@@ -262,7 +262,16 @@ export function ThreadsProvider<
     if (!agentInboxes || !agentInboxes.length) {
       setAgentInboxes([agentInbox]);
       setItem(AGENT_INBOXES_LOCAL_STORAGE_KEY, JSON.stringify([agentInbox]));
-      updateQueryParams(AGENT_INBOX_PARAM, agentInbox.id);
+      // Use URL replacement to fully refresh with new inbox
+      const url = new URL(window.location.href);
+      const newParams = new URLSearchParams({
+        [AGENT_INBOX_PARAM]: agentInbox.id,
+        [INBOX_PARAM]: "interrupted", // Default inbox type
+        [OFFSET_PARAM]: "0",
+        [LIMIT_PARAM]: "10",
+      });
+      const newUrl = url.pathname + "?" + newParams.toString();
+      window.location.href = newUrl;
       return;
     }
     const parsedAgentInboxes = JSON.parse(agentInboxes);
@@ -272,7 +281,16 @@ export function ThreadsProvider<
       AGENT_INBOXES_LOCAL_STORAGE_KEY,
       JSON.stringify(parsedAgentInboxes)
     );
-    updateQueryParams(AGENT_INBOX_PARAM, agentInbox.id);
+    // Use URL replacement to fully refresh with new inbox
+    const url = new URL(window.location.href);
+    const newParams = new URLSearchParams({
+      [AGENT_INBOX_PARAM]: agentInbox.id,
+      [INBOX_PARAM]: "interrupted", // Default inbox type
+      [OFFSET_PARAM]: "0",
+      [LIMIT_PARAM]: "10",
+    });
+    const newUrl = url.pathname + "?" + newParams.toString();
+    window.location.href = newUrl;
   }, []);
 
   const deleteAgentInbox = React.useCallback((id: string) => {


### PR DESCRIPTION
## URL Navigation for New Inbox Creation

## Changes

Instead of just updating the `AGENT_INBOX_PARAM` query parameter, this solution now:

- Creates a complete URL with all necessary parameters:
  - `AGENT_INBOX_PARAM`: The ID of the newly created inbox
  - `INBOX_PARAM`: Set to "interrupted" as the default view
  - `OFFSET_PARAM` and `LIMIT_PARAM`: Set to default pagination values
  
- Uses `window.location.href` to perform a complete page reload with the new URL parameters, which triggers:
  - A full refresh of the application state
  - Selection of the new inbox
  - Fetching of threads for the selected inbox with the specified type

## Benefits

This approach ensures that when a user creates a new inbox, the application immediately switches to that inbox and loads the appropriate threads without requiring manual intervention.