### PR TITLE
fix: change view scroll 53 v2

### DIFF
--- a/src/components/agent-inbox/components/inbox-item.tsx
+++ b/src/components/agent-inbox/components/inbox-item.tsx
@@ -10,11 +10,12 @@ interface InboxItemProps<
 > {
   threadData: ThreadData<ThreadValues>;
   isLast: boolean;
+  onThreadClick?: () => void;
 }
 
 export function InboxItem<
   ThreadValues extends Record<string, any> = Record<string, any>,
->({ threadData, isLast }: InboxItemProps<ThreadValues>) {
+>({ threadData, isLast, onThreadClick }: InboxItemProps<ThreadValues>) {
   const { searchParams } = useQueryParams();
 
   const inbox = (searchParams.get(INBOX_PARAM) ||
@@ -31,6 +32,7 @@ export function InboxItem<
               }
             }
             isLast={isLast}
+            onThreadClick={onThreadClick}
           />
         );
       } else {
@@ -58,6 +60,7 @@ export function InboxItem<
             }
           }
           isLast={isLast}
+          onThreadClick={onThreadClick}
         />
       );
     } else {

--- a/src/components/agent-inbox/components/interrupted-inbox-item.tsx
+++ b/src/components/agent-inbox/components/interrupted-inbox-item.tsx
@@ -38,14 +38,12 @@ export function InterruptedInboxItem<
   const handleThreadClick = (e: React.MouseEvent) => {
     e.preventDefault(); // Prevent default click behavior
 
-    // First call the onThreadClick callback provided by the parent
-    // This now contains the improved scroll detection logic
+    // Call the onThreadClick callback first to save scroll position
     if (onThreadClick) {
       onThreadClick();
     }
 
-    // Then navigate to thread view after a short delay
-    // to ensure scroll position is properly saved
+    // Small delay to ensure scroll position is captured before navigation
     setTimeout(() => {
       updateQueryParams(
         VIEW_STATE_THREAD_QUERY_PARAM,

--- a/src/components/agent-inbox/components/interrupted-inbox-item.tsx
+++ b/src/components/agent-inbox/components/interrupted-inbox-item.tsx
@@ -37,13 +37,13 @@ export function InterruptedInboxItem<
 
   const handleThreadClick = (e: React.MouseEvent) => {
     e.preventDefault(); // Prevent default click behavior
-    
+
     // First call the onThreadClick callback provided by the parent
     // This now contains the improved scroll detection logic
     if (onThreadClick) {
       onThreadClick();
     }
-    
+
     // Then navigate to thread view after a short delay
     // to ensure scroll position is properly saved
     setTimeout(() => {

--- a/src/components/agent-inbox/components/interrupted-inbox-item.tsx
+++ b/src/components/agent-inbox/components/interrupted-inbox-item.tsx
@@ -16,11 +16,12 @@ interface InterruptedInboxItem<
     interrupts: HumanInterrupt[];
   };
   isLast: boolean;
+  onThreadClick?: () => void;
 }
 
 export function InterruptedInboxItem<
   ThreadValues extends Record<string, any> = Record<string, any>,
->({ threadData, isLast }: InterruptedInboxItem<ThreadValues>) {
+>({ threadData, isLast, onThreadClick }: InterruptedInboxItem<ThreadValues>) {
   const { updateQueryParams } = useQueryParams();
   const descriptionPreview =
     threadData.interrupts[0].description &&
@@ -34,14 +35,28 @@ export function InterruptedInboxItem<
     "MM/dd h:mm a"
   );
 
+  const handleThreadClick = (e: React.MouseEvent) => {
+    e.preventDefault(); // Prevent default click behavior
+    
+    // First call the onThreadClick callback provided by the parent
+    // This now contains the improved scroll detection logic
+    if (onThreadClick) {
+      onThreadClick();
+    }
+    
+    // Then navigate to thread view after a short delay
+    // to ensure scroll position is properly saved
+    setTimeout(() => {
+      updateQueryParams(
+        VIEW_STATE_THREAD_QUERY_PARAM,
+        threadData.thread.thread_id
+      );
+    }, 50);
+  };
+
   return (
     <div
-      onClick={() =>
-        updateQueryParams(
-          VIEW_STATE_THREAD_QUERY_PARAM,
-          threadData.thread.thread_id
-        )
-      }
+      onClick={handleThreadClick}
       className={cn(
         "grid grid-cols-12 w-full p-6 items-center cursor-pointer hover:bg-gray-50/90 transition-colors ease-in-out",
         !isLast && "border-b-[1px] border-gray-200"

--- a/src/components/agent-inbox/components/interrupted-inbox-item.tsx
+++ b/src/components/agent-inbox/components/interrupted-inbox-item.tsx
@@ -43,13 +43,12 @@ export function InterruptedInboxItem<
       onThreadClick();
     }
 
-    // Small delay to ensure scroll position is captured before navigation
-    setTimeout(() => {
-      updateQueryParams(
-        VIEW_STATE_THREAD_QUERY_PARAM,
-        threadData.thread.thread_id
-      );
-    }, 50);
+    // Navigate immediately using the NextJS router approach
+    // The scroll option is set to false in updateQueryParams to prevent auto-scrolling
+    updateQueryParams(
+      VIEW_STATE_THREAD_QUERY_PARAM,
+      threadData.thread.thread_id
+    );
   };
 
   return (

--- a/src/components/agent-inbox/components/thread-actions-view.tsx
+++ b/src/components/agent-inbox/components/thread-actions-view.tsx
@@ -133,9 +133,11 @@ export function ThreadActionsView<
       <div className="flex flex-wrap items-center justify-between w-full gap-3">
         <div className="flex items-center justify-start gap-3">
           <TooltipIconButton
+            tooltip="Back to inbox"
             variant="ghost"
-            onClick={() => updateQueryParams(VIEW_STATE_THREAD_QUERY_PARAM)}
-            tooltip="Back"
+            onClick={() => {
+              updateQueryParams(VIEW_STATE_THREAD_QUERY_PARAM);
+            }}
           >
             <ArrowLeft className="w-5 h-5" />
           </TooltipIconButton>

--- a/src/components/agent-inbox/hooks/use-scroll-position.tsx
+++ b/src/components/agent-inbox/hooks/use-scroll-position.tsx
@@ -11,9 +11,6 @@ export function useScrollPosition() {
   // Track which element was scrolled
   const scrollElementRef = React.useRef<"window" | "element">("window");
 
-  // Debug flag to help with troubleshooting
-  const debug = true;
-
   // Save the current scroll position
   const saveScrollPosition = React.useCallback(
     (element?: HTMLElement | null) => {
@@ -23,19 +20,9 @@ export function useScrollPosition() {
       if (element && element.scrollTop > 0) {
         scrollPositionRef.current = element.scrollTop;
         scrollElementRef.current = "element";
-
-        if (debug) {
-          console.log(
-            `Saved element scroll position: ${element.scrollTop}px (ID: ${element.id || "unknown"})`
-          );
-        }
       } else {
         scrollPositionRef.current = window.scrollY;
         scrollElementRef.current = "window";
-
-        if (debug) {
-          console.log(`Saved window scroll position: ${window.scrollY}px`);
-        }
       }
     },
     []
@@ -49,16 +36,7 @@ export function useScrollPosition() {
       const position = scrollPositionRef.current;
       const elementType = scrollElementRef.current;
 
-      if (debug) {
-        console.log(
-          `Attempting to restore scroll position to: ${position}px (type: ${elementType})`
-        );
-      }
-
       if (position <= 0) {
-        console.log(
-          "Warning: Saved scroll position is 0 or negative, skipping restoration"
-        );
         return;
       }
 
@@ -67,35 +45,9 @@ export function useScrollPosition() {
         // Try the provided element first
         if (element && elementType === "element") {
           element.scrollTop = position;
-
-          if (debug) {
-            console.log(
-              `Set element.scrollTop to ${position}px, actual: ${element.scrollTop}px`
-            );
-
-            // If the restoration failed, log a warning
-            if (Math.abs(element.scrollTop - position) > 5) {
-              console.warn(
-                "Scroll restoration didn't work as expected on the element"
-              );
-            }
-          }
         } else {
           // Fall back to window scroll
           window.scrollTo(0, position);
-
-          if (debug) {
-            console.log(
-              `Set window.scrollTo(0, ${position}), actual: ${window.scrollY}px`
-            );
-
-            // If the restoration failed, log a warning
-            if (Math.abs(window.scrollY - position) > 5) {
-              console.warn(
-                "Scroll restoration didn't work as expected on window"
-              );
-            }
-          }
         }
       });
     },

--- a/src/components/agent-inbox/hooks/use-scroll-position.tsx
+++ b/src/components/agent-inbox/hooks/use-scroll-position.tsx
@@ -7,84 +7,104 @@ import * as React from "react";
 export function useScrollPosition() {
   // Use ref to persist scroll position value between renders
   const scrollPositionRef = React.useRef<number>(0);
-  
+
   // Track which element was scrolled
-  const scrollElementRef = React.useRef<'window' | 'element'>('window');
-  
+  const scrollElementRef = React.useRef<"window" | "element">("window");
+
   // Debug flag to help with troubleshooting
   const debug = true;
 
   // Save the current scroll position
-  const saveScrollPosition = React.useCallback((element?: HTMLElement | null) => {
-    if (typeof window === "undefined") return;
-    
-    // If element is provided, use its scrollTop, otherwise use window.scrollY
-    if (element && element.scrollTop > 0) {
-      scrollPositionRef.current = element.scrollTop;
-      scrollElementRef.current = 'element';
-      
-      if (debug) {
-        console.log(`Saved element scroll position: ${element.scrollTop}px (ID: ${element.id || 'unknown'})`);
-      }
-    } else {
-      scrollPositionRef.current = window.scrollY;
-      scrollElementRef.current = 'window';
-      
-      if (debug) {
-        console.log(`Saved window scroll position: ${window.scrollY}px`);
-      }
-    }
-  }, []);
+  const saveScrollPosition = React.useCallback(
+    (element?: HTMLElement | null) => {
+      if (typeof window === "undefined") return;
 
-  // Restore the saved scroll position
-  const restoreScrollPosition = React.useCallback((element?: HTMLElement | null) => {
-    if (typeof window === "undefined") return;
-    
-    const position = scrollPositionRef.current;
-    const elementType = scrollElementRef.current;
-    
-    if (debug) {
-      console.log(`Attempting to restore scroll position to: ${position}px (type: ${elementType})`);
-    }
-    
-    if (position <= 0) {
-      console.log("Warning: Saved scroll position is 0 or negative, skipping restoration");
-      return;
-    }
-    
-    // Use requestAnimationFrame to ensure DOM updates have completed
-    window.requestAnimationFrame(() => {
-      // Try the provided element first
-      if (element && elementType === 'element') {
-        element.scrollTop = position;
-        
+      // If element is provided, use its scrollTop, otherwise use window.scrollY
+      if (element && element.scrollTop > 0) {
+        scrollPositionRef.current = element.scrollTop;
+        scrollElementRef.current = "element";
+
         if (debug) {
-          console.log(`Set element.scrollTop to ${position}px, actual: ${element.scrollTop}px`);
-          
-          // If the restoration failed, log a warning
-          if (Math.abs(element.scrollTop - position) > 5) {
-            console.warn("Scroll restoration didn't work as expected on the element");
-          }
+          console.log(
+            `Saved element scroll position: ${element.scrollTop}px (ID: ${element.id || "unknown"})`
+          );
         }
       } else {
-        // Fall back to window scroll
-        window.scrollTo(0, position);
-        
+        scrollPositionRef.current = window.scrollY;
+        scrollElementRef.current = "window";
+
         if (debug) {
-          console.log(`Set window.scrollTo(0, ${position}), actual: ${window.scrollY}px`);
-          
-          // If the restoration failed, log a warning
-          if (Math.abs(window.scrollY - position) > 5) {
-            console.warn("Scroll restoration didn't work as expected on window");
-          }
+          console.log(`Saved window scroll position: ${window.scrollY}px`);
         }
       }
-    });
-  }, []);
+    },
+    []
+  );
+
+  // Restore the saved scroll position
+  const restoreScrollPosition = React.useCallback(
+    (element?: HTMLElement | null) => {
+      if (typeof window === "undefined") return;
+
+      const position = scrollPositionRef.current;
+      const elementType = scrollElementRef.current;
+
+      if (debug) {
+        console.log(
+          `Attempting to restore scroll position to: ${position}px (type: ${elementType})`
+        );
+      }
+
+      if (position <= 0) {
+        console.log(
+          "Warning: Saved scroll position is 0 or negative, skipping restoration"
+        );
+        return;
+      }
+
+      // Use requestAnimationFrame to ensure DOM updates have completed
+      window.requestAnimationFrame(() => {
+        // Try the provided element first
+        if (element && elementType === "element") {
+          element.scrollTop = position;
+
+          if (debug) {
+            console.log(
+              `Set element.scrollTop to ${position}px, actual: ${element.scrollTop}px`
+            );
+
+            // If the restoration failed, log a warning
+            if (Math.abs(element.scrollTop - position) > 5) {
+              console.warn(
+                "Scroll restoration didn't work as expected on the element"
+              );
+            }
+          }
+        } else {
+          // Fall back to window scroll
+          window.scrollTo(0, position);
+
+          if (debug) {
+            console.log(
+              `Set window.scrollTo(0, ${position}), actual: ${window.scrollY}px`
+            );
+
+            // If the restoration failed, log a warning
+            if (Math.abs(window.scrollY - position) > 5) {
+              console.warn(
+                "Scroll restoration didn't work as expected on window"
+              );
+            }
+          }
+        }
+      });
+    },
+    []
+  );
 
   return {
     scrollPosition: scrollPositionRef.current,
     saveScrollPosition,
-    restoreScrollPosition
+    restoreScrollPosition,
   };
-} 
+}

--- a/src/components/agent-inbox/hooks/use-scroll-position.tsx
+++ b/src/components/agent-inbox/hooks/use-scroll-position.tsx
@@ -44,10 +44,22 @@ export function useScrollPosition() {
       window.requestAnimationFrame(() => {
         // Try the provided element first
         if (element && elementType === "element") {
-          element.scrollTop = position;
+          // Use scrollTo with smooth behavior if supported
+          if ("scrollTo" in element) {
+            element.scrollTo({
+              top: position,
+              behavior: "smooth",
+            });
+          } else {
+            // Fallback for older browsers
+            (element as HTMLElement).scrollTop = position;
+          }
         } else {
-          // Fall back to window scroll
-          window.scrollTo(0, position);
+          // Fall back to window scroll with smooth behavior
+          window.scrollTo({
+            top: position,
+            behavior: "smooth",
+          });
         }
       });
     },

--- a/src/components/agent-inbox/hooks/use-scroll-position.tsx
+++ b/src/components/agent-inbox/hooks/use-scroll-position.tsx
@@ -1,0 +1,90 @@
+import * as React from "react";
+
+/**
+ * Custom hook to save and restore scroll position when navigating between views
+ * @returns Object containing scroll position and methods to save/restore it
+ */
+export function useScrollPosition() {
+  // Use ref to persist scroll position value between renders
+  const scrollPositionRef = React.useRef<number>(0);
+  
+  // Track which element was scrolled
+  const scrollElementRef = React.useRef<'window' | 'element'>('window');
+  
+  // Debug flag to help with troubleshooting
+  const debug = true;
+
+  // Save the current scroll position
+  const saveScrollPosition = React.useCallback((element?: HTMLElement | null) => {
+    if (typeof window === "undefined") return;
+    
+    // If element is provided, use its scrollTop, otherwise use window.scrollY
+    if (element && element.scrollTop > 0) {
+      scrollPositionRef.current = element.scrollTop;
+      scrollElementRef.current = 'element';
+      
+      if (debug) {
+        console.log(`Saved element scroll position: ${element.scrollTop}px (ID: ${element.id || 'unknown'})`);
+      }
+    } else {
+      scrollPositionRef.current = window.scrollY;
+      scrollElementRef.current = 'window';
+      
+      if (debug) {
+        console.log(`Saved window scroll position: ${window.scrollY}px`);
+      }
+    }
+  }, []);
+
+  // Restore the saved scroll position
+  const restoreScrollPosition = React.useCallback((element?: HTMLElement | null) => {
+    if (typeof window === "undefined") return;
+    
+    const position = scrollPositionRef.current;
+    const elementType = scrollElementRef.current;
+    
+    if (debug) {
+      console.log(`Attempting to restore scroll position to: ${position}px (type: ${elementType})`);
+    }
+    
+    if (position <= 0) {
+      console.log("Warning: Saved scroll position is 0 or negative, skipping restoration");
+      return;
+    }
+    
+    // Use requestAnimationFrame to ensure DOM updates have completed
+    window.requestAnimationFrame(() => {
+      // Try the provided element first
+      if (element && elementType === 'element') {
+        element.scrollTop = position;
+        
+        if (debug) {
+          console.log(`Set element.scrollTop to ${position}px, actual: ${element.scrollTop}px`);
+          
+          // If the restoration failed, log a warning
+          if (Math.abs(element.scrollTop - position) > 5) {
+            console.warn("Scroll restoration didn't work as expected on the element");
+          }
+        }
+      } else {
+        // Fall back to window scroll
+        window.scrollTo(0, position);
+        
+        if (debug) {
+          console.log(`Set window.scrollTo(0, ${position}), actual: ${window.scrollY}px`);
+          
+          // If the restoration failed, log a warning
+          if (Math.abs(window.scrollY - position) > 5) {
+            console.warn("Scroll restoration didn't work as expected on window");
+          }
+        }
+      }
+    });
+  }, []);
+
+  return {
+    scrollPosition: scrollPositionRef.current,
+    saveScrollPosition,
+    restoreScrollPosition
+  };
+} 

--- a/src/components/agent-inbox/inbox-view.tsx
+++ b/src/components/agent-inbox/inbox-view.tsx
@@ -134,11 +134,6 @@ export function AgentInboxView<
     }
   };
 
-  // And remove the Container ref set console log
-  React.useEffect(() => {
-    // Just track ref setup without logging
-  }, [containerRef.current]);
-
   return (
     <div ref={containerRef} className="min-w-[1000px] h-full overflow-y-auto">
       <div className="pl-5 pt-4">

--- a/src/components/agent-inbox/inbox-view.tsx
+++ b/src/components/agent-inbox/inbox-view.tsx
@@ -8,13 +8,59 @@ import { Pagination } from "./components/pagination";
 import { Inbox as InboxIcon, LoaderCircle } from "lucide-react";
 import { InboxButtons } from "./components/inbox-buttons";
 
+interface AgentInboxViewProps<ThreadValues> {
+  saveScrollPosition: (element?: HTMLElement | null) => void;
+  containerRef: React.RefObject<HTMLDivElement>;
+}
+
 export function AgentInboxView<
   ThreadValues extends Record<string, any> = Record<string, any>,
->() {
+>({ saveScrollPosition, containerRef }: AgentInboxViewProps<ThreadValues>) {
   const { searchParams, updateQueryParams, getSearchParam } = useQueryParams();
   const { loading, threadData } = useThreadsContext<ThreadValues>();
   const selectedInbox = (getSearchParam(INBOX_PARAM) ||
     "interrupted") as ThreadStatusWithAll;
+  const scrollableContentRef = React.useRef<HTMLDivElement>(null);
+  
+  // Register scroll event listener to automatically save scroll position whenever user scrolls
+  React.useEffect(() => {
+    if (typeof window === "undefined") return;
+    
+    // Define the scroll handler that will save the current scroll position
+    const handleScroll = () => {
+      // Find the element that's actually scrolling
+      if (scrollableContentRef.current && scrollableContentRef.current.scrollTop > 0) {
+        // First check the inner container (thread list)
+        saveScrollPosition(scrollableContentRef.current);
+      } else if (containerRef.current && containerRef.current.scrollTop > 0) {
+        // Then check the outer container
+        saveScrollPosition(containerRef.current);
+      } else if (window.scrollY > 0) {
+        // Finally check the window
+        saveScrollPosition();
+      }
+    };
+    
+    // We need to throttle the handler to avoid performance issues
+    let timeout: NodeJS.Timeout | null = null;
+    const throttledScrollHandler = () => {
+      if (!timeout) {
+        timeout = setTimeout(() => {
+          handleScroll();
+          timeout = null;
+        }, 300); // Only call every 300ms
+      }
+    };
+    
+    // Add the event listener
+    window.addEventListener('scroll', throttledScrollHandler, { passive: true });
+    
+    // Don't forget to clean up
+    return () => {
+      window.removeEventListener('scroll', throttledScrollHandler);
+      if (timeout) clearTimeout(timeout);
+    };
+  }, [containerRef, saveScrollPosition]);
 
   const changeInbox = async (inbox: ThreadStatusWithAll) => {
     updateQueryParams(
@@ -49,18 +95,64 @@ export function AgentInboxView<
   );
   const noThreadsFound = !threadDataToRender.length;
 
+  // Save the parent component reference to the main container
+  React.useEffect(() => {
+    if (containerRef.current) {
+      console.log("Container ref set to main container element");
+    }
+  }, [containerRef.current]);
+
+  // Correct way to save scroll position before navigation
+  const handleThreadClick = () => {
+    // First try the inner scrollable div
+    if (scrollableContentRef.current && scrollableContentRef.current.scrollTop > 0) {
+      console.log(`Saving inner scroll position: ${scrollableContentRef.current.scrollTop}px`);
+      saveScrollPosition(scrollableContentRef.current);
+    } 
+    // Then try the outer container
+    else if (containerRef.current && containerRef.current.scrollTop > 0) {
+      console.log(`Saving main container scroll position: ${containerRef.current.scrollTop}px`);
+      saveScrollPosition(containerRef.current);
+    }
+    // Finally try window
+    else if (window.scrollY > 0) {
+      console.log(`Saving window scroll position: ${window.scrollY}px`);
+      saveScrollPosition();
+    }
+    // If none have scroll, check why
+    else {
+      console.log("Warning: No scroll position detected! Element structure may have changed.");
+      
+      // Find all scrollable elements and log their scroll positions (for debugging)
+      const scrollableElements = document.querySelectorAll('[class*="overflow"]');
+      scrollableElements.forEach((el, i) => {
+        const htmlEl = el as HTMLElement;
+        if (htmlEl.scrollTop > 0) {
+          console.log(`Found scrollable element ${i}: ${htmlEl.scrollTop}px`);
+        }
+      });
+    }
+  };
+
   return (
-    <div className="min-w-[1000px] h-full overflow-y-auto">
+    <div 
+      ref={containerRef} 
+      className="min-w-[1000px] h-full overflow-y-auto"
+    >
       <div className="pl-5 pt-4">
         <InboxButtons changeInbox={changeInbox} />
       </div>
-      <div className="flex flex-col items-start w-full max-h-fit h-full border-y-[1px] border-gray-50 overflow-y-auto scrollbar-thin scrollbar-thumb-gray-300 scrollbar-track-gray-100 mt-3">
+      <div 
+        ref={scrollableContentRef}
+        className="flex flex-col items-start w-full max-h-fit h-full border-y-[1px] border-gray-50 overflow-y-auto scrollbar-thin scrollbar-thumb-gray-300 scrollbar-track-gray-100 mt-3"
+      >
         {threadDataToRender.map((threadData, idx) => {
           return (
             <InboxItem<ThreadValues>
               key={`inbox-item-${threadData.thread.thread_id}`}
               threadData={threadData}
               isLast={idx === threadDataToRender.length - 1}
+              onThreadClick={handleThreadClick}
             />
           );
         })}

--- a/src/components/agent-inbox/inbox-view.tsx
+++ b/src/components/agent-inbox/inbox-view.tsx
@@ -8,7 +8,9 @@ import { Pagination } from "./components/pagination";
 import { Inbox as InboxIcon, LoaderCircle } from "lucide-react";
 import { InboxButtons } from "./components/inbox-buttons";
 
-interface AgentInboxViewProps<ThreadValues> {
+interface AgentInboxViewProps<
+  _ThreadValues extends Record<string, any> = Record<string, any>,
+> {
   saveScrollPosition: (element?: HTMLElement | null) => void;
   containerRef: React.RefObject<HTMLDivElement>;
 }
@@ -21,15 +23,18 @@ export function AgentInboxView<
   const selectedInbox = (getSearchParam(INBOX_PARAM) ||
     "interrupted") as ThreadStatusWithAll;
   const scrollableContentRef = React.useRef<HTMLDivElement>(null);
-  
+
   // Register scroll event listener to automatically save scroll position whenever user scrolls
   React.useEffect(() => {
     if (typeof window === "undefined") return;
-    
+
     // Define the scroll handler that will save the current scroll position
     const handleScroll = () => {
       // Find the element that's actually scrolling
-      if (scrollableContentRef.current && scrollableContentRef.current.scrollTop > 0) {
+      if (
+        scrollableContentRef.current &&
+        scrollableContentRef.current.scrollTop > 0
+      ) {
         // First check the inner container (thread list)
         saveScrollPosition(scrollableContentRef.current);
       } else if (containerRef.current && containerRef.current.scrollTop > 0) {
@@ -40,7 +45,7 @@ export function AgentInboxView<
         saveScrollPosition();
       }
     };
-    
+
     // We need to throttle the handler to avoid performance issues
     let timeout: NodeJS.Timeout | null = null;
     const throttledScrollHandler = () => {
@@ -51,13 +56,15 @@ export function AgentInboxView<
         }, 300); // Only call every 300ms
       }
     };
-    
+
     // Add the event listener
-    window.addEventListener('scroll', throttledScrollHandler, { passive: true });
-    
+    window.addEventListener("scroll", throttledScrollHandler, {
+      passive: true,
+    });
+
     // Don't forget to clean up
     return () => {
-      window.removeEventListener('scroll', throttledScrollHandler);
+      window.removeEventListener("scroll", throttledScrollHandler);
       if (timeout) clearTimeout(timeout);
     };
   }, [containerRef, saveScrollPosition]);
@@ -105,13 +112,20 @@ export function AgentInboxView<
   // Correct way to save scroll position before navigation
   const handleThreadClick = () => {
     // First try the inner scrollable div
-    if (scrollableContentRef.current && scrollableContentRef.current.scrollTop > 0) {
-      console.log(`Saving inner scroll position: ${scrollableContentRef.current.scrollTop}px`);
+    if (
+      scrollableContentRef.current &&
+      scrollableContentRef.current.scrollTop > 0
+    ) {
+      console.log(
+        `Saving inner scroll position: ${scrollableContentRef.current.scrollTop}px`
+      );
       saveScrollPosition(scrollableContentRef.current);
-    } 
+    }
     // Then try the outer container
     else if (containerRef.current && containerRef.current.scrollTop > 0) {
-      console.log(`Saving main container scroll position: ${containerRef.current.scrollTop}px`);
+      console.log(
+        `Saving main container scroll position: ${containerRef.current.scrollTop}px`
+      );
       saveScrollPosition(containerRef.current);
     }
     // Finally try window
@@ -121,10 +135,14 @@ export function AgentInboxView<
     }
     // If none have scroll, check why
     else {
-      console.log("Warning: No scroll position detected! Element structure may have changed.");
-      
+      console.log(
+        "Warning: No scroll position detected! Element structure may have changed."
+      );
+
       // Find all scrollable elements and log their scroll positions (for debugging)
-      const scrollableElements = document.querySelectorAll('[class*="overflow"]');
+      const scrollableElements = document.querySelectorAll(
+        '[class*="overflow"]'
+      );
       scrollableElements.forEach((el, i) => {
         const htmlEl = el as HTMLElement;
         if (htmlEl.scrollTop > 0) {
@@ -135,14 +153,11 @@ export function AgentInboxView<
   };
 
   return (
-    <div 
-      ref={containerRef} 
-      className="min-w-[1000px] h-full overflow-y-auto"
-    >
+    <div ref={containerRef} className="min-w-[1000px] h-full overflow-y-auto">
       <div className="pl-5 pt-4">
         <InboxButtons changeInbox={changeInbox} />
       </div>
-      <div 
+      <div
         ref={scrollableContentRef}
         className="flex flex-col items-start w-full max-h-fit h-full border-y-[1px] border-gray-50 overflow-y-auto scrollbar-thin scrollbar-thumb-gray-300 scrollbar-track-gray-100 mt-3"
       >

--- a/src/components/agent-inbox/inbox-view.tsx
+++ b/src/components/agent-inbox/inbox-view.tsx
@@ -102,13 +102,6 @@ export function AgentInboxView<
   );
   const noThreadsFound = !threadDataToRender.length;
 
-  // Save the parent component reference to the main container
-  React.useEffect(() => {
-    if (containerRef.current) {
-      console.log("Container ref set to main container element");
-    }
-  }, [containerRef.current]);
-
   // Correct way to save scroll position before navigation
   const handleThreadClick = () => {
     // First try the inner scrollable div
@@ -116,41 +109,35 @@ export function AgentInboxView<
       scrollableContentRef.current &&
       scrollableContentRef.current.scrollTop > 0
     ) {
-      console.log(
-        `Saving inner scroll position: ${scrollableContentRef.current.scrollTop}px`
-      );
       saveScrollPosition(scrollableContentRef.current);
     }
     // Then try the outer container
     else if (containerRef.current && containerRef.current.scrollTop > 0) {
-      console.log(
-        `Saving main container scroll position: ${containerRef.current.scrollTop}px`
-      );
       saveScrollPosition(containerRef.current);
     }
     // Finally try window
     else if (window.scrollY > 0) {
-      console.log(`Saving window scroll position: ${window.scrollY}px`);
       saveScrollPosition();
     }
-    // If none have scroll, check why
+    // If none have scroll, find scrollable elements as fallback
     else {
-      console.log(
-        "Warning: No scroll position detected! Element structure may have changed."
-      );
-
-      // Find all scrollable elements and log their scroll positions (for debugging)
       const scrollableElements = document.querySelectorAll(
         '[class*="overflow"]'
       );
-      scrollableElements.forEach((el, i) => {
+      scrollableElements.forEach((el) => {
         const htmlEl = el as HTMLElement;
         if (htmlEl.scrollTop > 0) {
-          console.log(`Found scrollable element ${i}: ${htmlEl.scrollTop}px`);
+          saveScrollPosition(htmlEl);
+          return;
         }
       });
     }
   };
+
+  // And remove the Container ref set console log
+  React.useEffect(() => {
+    // Just track ref setup without logging
+  }, [containerRef.current]);
 
   return (
     <div ref={containerRef} className="min-w-[1000px] h-full overflow-y-auto">

--- a/src/components/agent-inbox/index.tsx
+++ b/src/components/agent-inbox/index.tsx
@@ -4,6 +4,7 @@ import { INBOX_PARAM, VIEW_STATE_THREAD_QUERY_PARAM } from "./constants";
 import { ThreadStatusWithAll } from "./types";
 import { AgentInboxView } from "./inbox-view";
 import { ThreadView } from "./thread-view";
+import { useScrollPosition } from "./hooks/use-scroll-position";
 
 export function AgentInbox<
   ThreadValues extends Record<string, any> = Record<string, any>,
@@ -11,9 +12,68 @@ export function AgentInbox<
   const { searchParams, updateQueryParams, getSearchParam } = useQueryParams();
   const [selectedInbox, setSelectedInbox] =
     React.useState<ThreadStatusWithAll>("interrupted");
+  const { scrollPosition, saveScrollPosition, restoreScrollPosition } = useScrollPosition();
+  const containerRef = React.useRef<HTMLDivElement>(null);
 
   const selectedThreadIdParam = searchParams.get(VIEW_STATE_THREAD_QUERY_PARAM);
   const isStateViewOpen = !!selectedThreadIdParam;
+  const prevIsStateViewOpen = React.useRef<boolean>(false);
+  
+  // Need to track first render to avoid restoring scroll on initial page load
+  const isFirstRender = React.useRef(true);
+
+  // Track URL changes to detect when the thread ID changes (not just appears/disappears)
+  const lastThreadId = React.useRef<string | null>(null);
+
+  // Effect to handle transitions between list and thread views
+  React.useEffect(() => {
+    if (typeof window === "undefined") return;
+    
+    // Skip during first render
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      prevIsStateViewOpen.current = isStateViewOpen;
+      lastThreadId.current = selectedThreadIdParam;
+      return;
+    }
+    
+    // Case 1: Going from list view to thread view
+    if (!prevIsStateViewOpen.current && isStateViewOpen) {
+      console.log("Transitioning from list to thread view, saving scroll position...");
+      
+      // Try to save scroll position
+      if (window.scrollY > 0) {
+        saveScrollPosition(); // Save window scroll
+      } else if (containerRef.current && containerRef.current.scrollTop > 0) {
+        saveScrollPosition(containerRef.current);
+      }
+    }
+    // Case 2: Going from thread view to list view
+    else if (prevIsStateViewOpen.current && !isStateViewOpen) {
+      console.log("Transitioning back to list view, restoring scroll position...");
+      
+      // Try multiple times to restore scroll with increasing delays
+      const maxAttempts = 5;
+      
+      for (let i = 0; i < maxAttempts; i++) {
+        setTimeout(() => {
+          if (containerRef.current) {
+            console.log(`Restore attempt ${i+1}/${maxAttempts}`);
+            restoreScrollPosition(containerRef.current);
+          }
+        }, 50 * (i + 1));
+      }
+    }
+    // Case 3: Switching between different thread views
+    else if (prevIsStateViewOpen.current && isStateViewOpen && 
+             lastThreadId.current !== selectedThreadIdParam) {
+      console.log("Switching between different threads, no scroll action needed");
+    }
+    
+    // Update previous state for next render
+    prevIsStateViewOpen.current = isStateViewOpen;
+    lastThreadId.current = selectedThreadIdParam;
+  }, [isStateViewOpen, selectedThreadIdParam, saveScrollPosition, restoreScrollPosition]);
 
   React.useEffect(() => {
     try {
@@ -37,5 +97,10 @@ export function AgentInbox<
     return <ThreadView threadId={selectedThreadIdParam} />;
   }
 
-  return <AgentInboxView<ThreadValues> />;
+  return (
+    <AgentInboxView<ThreadValues> 
+      saveScrollPosition={saveScrollPosition}
+      containerRef={containerRef} 
+    />
+  );
 }

--- a/src/components/agent-inbox/index.tsx
+++ b/src/components/agent-inbox/index.tsx
@@ -39,10 +39,6 @@ export function AgentInbox<
 
     // Case 1: Going from list view to thread view
     if (!prevIsStateViewOpen.current && isStateViewOpen) {
-      console.log(
-        "Transitioning from list to thread view, saving scroll position..."
-      );
-
       // Try to save scroll position
       if (window.scrollY > 0) {
         saveScrollPosition(); // Save window scroll
@@ -52,10 +48,6 @@ export function AgentInbox<
     }
     // Case 2: Going from thread view to list view
     else if (prevIsStateViewOpen.current && !isStateViewOpen) {
-      console.log(
-        "Transitioning back to list view, restoring scroll position..."
-      );
-
       // Try multiple times to restore scroll with increasing delays
       const maxAttempts = 5;
 
@@ -63,7 +55,6 @@ export function AgentInbox<
         setTimeout(
           () => {
             if (containerRef.current) {
-              console.log(`Restore attempt ${i + 1}/${maxAttempts}`);
               restoreScrollPosition(containerRef.current);
             }
           },
@@ -77,9 +68,7 @@ export function AgentInbox<
       isStateViewOpen &&
       lastThreadId.current !== selectedThreadIdParam
     ) {
-      console.log(
-        "Switching between different threads, no scroll action needed"
-      );
+      // No action needed when switching between thread views
     }
 
     // Update previous state for next render

--- a/src/components/agent-inbox/index.tsx
+++ b/src/components/agent-inbox/index.tsx
@@ -12,13 +12,13 @@ export function AgentInbox<
   const { searchParams, updateQueryParams, getSearchParam } = useQueryParams();
   const [selectedInbox, setSelectedInbox] =
     React.useState<ThreadStatusWithAll>("interrupted");
-  const { scrollPosition, saveScrollPosition, restoreScrollPosition } = useScrollPosition();
+  const { saveScrollPosition, restoreScrollPosition } = useScrollPosition();
   const containerRef = React.useRef<HTMLDivElement>(null);
 
   const selectedThreadIdParam = searchParams.get(VIEW_STATE_THREAD_QUERY_PARAM);
   const isStateViewOpen = !!selectedThreadIdParam;
   const prevIsStateViewOpen = React.useRef<boolean>(false);
-  
+
   // Need to track first render to avoid restoring scroll on initial page load
   const isFirstRender = React.useRef(true);
 
@@ -28,7 +28,7 @@ export function AgentInbox<
   // Effect to handle transitions between list and thread views
   React.useEffect(() => {
     if (typeof window === "undefined") return;
-    
+
     // Skip during first render
     if (isFirstRender.current) {
       isFirstRender.current = false;
@@ -36,11 +36,13 @@ export function AgentInbox<
       lastThreadId.current = selectedThreadIdParam;
       return;
     }
-    
+
     // Case 1: Going from list view to thread view
     if (!prevIsStateViewOpen.current && isStateViewOpen) {
-      console.log("Transitioning from list to thread view, saving scroll position...");
-      
+      console.log(
+        "Transitioning from list to thread view, saving scroll position..."
+      );
+
       // Try to save scroll position
       if (window.scrollY > 0) {
         saveScrollPosition(); // Save window scroll
@@ -50,30 +52,45 @@ export function AgentInbox<
     }
     // Case 2: Going from thread view to list view
     else if (prevIsStateViewOpen.current && !isStateViewOpen) {
-      console.log("Transitioning back to list view, restoring scroll position...");
-      
+      console.log(
+        "Transitioning back to list view, restoring scroll position..."
+      );
+
       // Try multiple times to restore scroll with increasing delays
       const maxAttempts = 5;
-      
+
       for (let i = 0; i < maxAttempts; i++) {
-        setTimeout(() => {
-          if (containerRef.current) {
-            console.log(`Restore attempt ${i+1}/${maxAttempts}`);
-            restoreScrollPosition(containerRef.current);
-          }
-        }, 50 * (i + 1));
+        setTimeout(
+          () => {
+            if (containerRef.current) {
+              console.log(`Restore attempt ${i + 1}/${maxAttempts}`);
+              restoreScrollPosition(containerRef.current);
+            }
+          },
+          50 * (i + 1)
+        );
       }
     }
     // Case 3: Switching between different thread views
-    else if (prevIsStateViewOpen.current && isStateViewOpen && 
-             lastThreadId.current !== selectedThreadIdParam) {
-      console.log("Switching between different threads, no scroll action needed");
+    else if (
+      prevIsStateViewOpen.current &&
+      isStateViewOpen &&
+      lastThreadId.current !== selectedThreadIdParam
+    ) {
+      console.log(
+        "Switching between different threads, no scroll action needed"
+      );
     }
-    
+
     // Update previous state for next render
     prevIsStateViewOpen.current = isStateViewOpen;
     lastThreadId.current = selectedThreadIdParam;
-  }, [isStateViewOpen, selectedThreadIdParam, saveScrollPosition, restoreScrollPosition]);
+  }, [
+    isStateViewOpen,
+    selectedThreadIdParam,
+    saveScrollPosition,
+    restoreScrollPosition,
+  ]);
 
   React.useEffect(() => {
     try {
@@ -98,9 +115,9 @@ export function AgentInbox<
   }
 
   return (
-    <AgentInboxView<ThreadValues> 
+    <AgentInboxView<ThreadValues>
       saveScrollPosition={saveScrollPosition}
-      containerRef={containerRef} 
+      containerRef={containerRef}
     />
   );
 }

--- a/src/components/agent-inbox/thread-view.tsx
+++ b/src/components/agent-inbox/thread-view.tsx
@@ -19,6 +19,13 @@ export function ThreadView<
   const [showState, setShowState] = React.useState(false);
   const showSidePanel = showDescription || showState;
 
+  // Scroll to top when thread view is mounted
+  React.useEffect(() => {
+    if (typeof window !== "undefined") {
+      window.scrollTo(0, 0);
+    }
+  }, []);
+
   React.useEffect(() => {
     try {
       if (typeof window === "undefined") return;


### PR DESCRIPTION
<div>
    <a href="https://www.loom.com/share/263e21a64b414ae88b3575bafff3d307">
      <p>Scroll Functionality Loom - Watch Video</p>
    </a>
    <a href="https://www.loom.com/share/263e21a64b414ae88b3575bafff3d307">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/263e21a64b414ae88b3575bafff3d307-e884951abb979f10-full-play.gif">
    </a>
  </div>

fixes #53 
fixes #56 


# PR: Scroll Position Persistence Between Views

## Problem Solved
This PR fixes scroll position behavior when navigating through the application:
- List view preserves scroll position when returning from thread views
- Thread detail views always start at the top
- Works across multiple navigation sequences (list → thread → back to list → another thread → back to list)

## Implementation
Created a custom scroll position management system using:
- A `useScrollPosition` hook to save/restore scroll positions
- Intelligent detection of scrollable elements
- Multiple restoration attempts to ensure reliable positioning

## Key Technical Features
1. Ref-based position tracking that persists across navigation
2. Smart detection of which element is actually scrolling
3. Multiple restoration attempts with delayed timing
4. Event throttling for performance optimization

## Benefits
- Better UX: Users don't lose their place when navigating back
- Consistent behavior: Thread views start at top, list views maintain position
- Resilient implementation: Works across different navigation paths

The implementation is lightweight, isolated, and significantly improves navigation fluidity in the application.


