### PR TITLE
feat: Support opening the "thread view" for threads which are not interrupted

### DIFF
--- a/src/components/agent-inbox/components/breadcrumb.tsx
+++ b/src/components/agent-inbox/components/breadcrumb.tsx
@@ -77,7 +77,15 @@ export function BreadCrumb({ className }: { className?: string }) {
   };
 
   if (!agentInboxLabel) {
-    return null;
+    return (
+      <div
+        className={cn(
+          "flex items-center justify-start gap-2 text-gray-500 text-sm h-[34px]",
+          className
+        )}
+        aria-hidden="true"
+      />
+    );
   }
 
   return (

--- a/src/components/agent-inbox/components/generic-inbox-item.tsx
+++ b/src/components/agent-inbox/components/generic-inbox-item.tsx
@@ -9,6 +9,8 @@ import { constructOpenInStudioURL } from "../utils";
 import { Button } from "@/components/ui/button";
 import NextLink from "next/link";
 import { useThreadsContext } from "../contexts/ThreadContext";
+import { useQueryParams } from "../hooks/use-query-params";
+import { VIEW_STATE_THREAD_QUERY_PARAM } from "../constants";
 
 interface GenericInboxItemProps<
   ThreadValues extends Record<string, any> = Record<string, any>,
@@ -26,6 +28,7 @@ export function GenericInboxItem<
 >({ threadData, isLast }: GenericInboxItemProps<ThreadValues>) {
   const { agentInboxes } = useThreadsContext<ThreadValues>();
   const { toast } = useToast();
+  const { updateQueryParams } = useQueryParams();
 
   const deploymentUrl = agentInboxes.find((i) => i.selected)?.deploymentUrl;
 
@@ -53,8 +56,14 @@ export function GenericInboxItem<
 
   return (
     <div
+      onClick={() =>
+        updateQueryParams(
+          VIEW_STATE_THREAD_QUERY_PARAM,
+          threadData.thread.thread_id
+        )
+      }
       className={cn(
-        "grid grid-cols-12 w-full p-7 items-center",
+        "grid grid-cols-12 w-full p-7 items-center cursor-pointer hover:bg-gray-50/90 transition-colors ease-in-out",
         !isLast && "border-b-[1px] border-gray-200"
       )}
     >

--- a/src/components/agent-inbox/components/state-view.tsx
+++ b/src/components/agent-inbox/components/state-view.tsx
@@ -250,7 +250,17 @@ export function StateView({
   const [expanded, setExpanded] = useState(false);
 
   const threadValues = threadData.thread.values;
-  const description = threadData.interrupts?.[0].description;
+  const description = threadData.interrupts?.[0]?.description;
+  const isInterrupted =
+    threadData.status === "interrupted" &&
+    threadData.interrupts &&
+    threadData.interrupts.length > 0;
+
+  // Format dates for display
+  const createdAt = new Date(threadData.thread.created_at);
+  const updatedAt = new Date(threadData.thread.updated_at);
+  const formattedCreatedAt = createdAt.toLocaleString();
+  const formattedUpdatedAt = updatedAt.toLocaleString();
 
   if (!threadValues) {
     return <div>No state found</div>;
@@ -258,11 +268,66 @@ export function StateView({
 
   return (
     <div className="overflow-y-auto pl-6 border-t-[1px] lg:border-t-[0px] lg:border-l-[1px] border-gray-100 flex flex-row gap-0 w-full">
-      {view === "description" && (
+      {view === "description" && isInterrupted && (
         <div className="pt-6 pb-2">
           <MarkdownText className="text-wrap break-words whitespace-pre-wrap">
             {description || "No description provided"}
           </MarkdownText>
+        </div>
+      )}
+      {view === "description" && !isInterrupted && (
+        <div className="pt-6 pb-2 w-full">
+          <h3 className="text-lg font-medium mb-4">Thread Information</h3>
+
+          <div className="grid grid-cols-1 gap-3">
+            <div>
+              <h4 className="text-sm font-semibold text-gray-700">Status</h4>
+              <div className="mt-1 flex items-center">
+                <div
+                  className={cn(
+                    "w-3 h-3 rounded-full mr-2",
+                    threadData.status === "idle"
+                      ? "bg-gray-400"
+                      : threadData.status === "busy"
+                        ? "bg-blue-500"
+                        : "bg-red-500"
+                  )}
+                ></div>
+                <p className="text-sm capitalize">{threadData.status}</p>
+              </div>
+            </div>
+
+            <div>
+              <h4 className="text-sm font-semibold text-gray-700">Thread ID</h4>
+              <p className="text-sm font-mono mt-1">
+                {threadData.thread.thread_id}
+              </p>
+            </div>
+
+            <div>
+              <h4 className="text-sm font-semibold text-gray-700">
+                Created At
+              </h4>
+              <p className="text-sm mt-1">{formattedCreatedAt}</p>
+            </div>
+
+            <div>
+              <h4 className="text-sm font-semibold text-gray-700">
+                Last Updated
+              </h4>
+              <p className="text-sm mt-1">{formattedUpdatedAt}</p>
+            </div>
+
+            <div className="mt-2">
+              <h4 className="text-sm font-semibold text-gray-700">
+                Thread State Summary
+              </h4>
+              <p className="text-sm mt-1 italic">
+                View the complete state in the &quot;State&quot; tab for
+                detailed information.
+              </p>
+            </div>
+          </div>
         </div>
       )}
       {view === "state" && (

--- a/src/components/agent-inbox/components/state-view.tsx
+++ b/src/components/agent-inbox/components/state-view.tsx
@@ -10,10 +10,17 @@ import { motion } from "framer-motion";
 import { cn } from "@/lib/utils";
 import { BaseMessage } from "@langchain/core/messages";
 import { ToolCall } from "@langchain/core/messages/tool";
+import React from "react";
 import { Button } from "../../ui/button";
 import { ToolCallTable } from "./tool-call-table";
 import { MarkdownText } from "@/components/ui/markdown-text";
 import { ThreadData } from "../types";
+import {
+  EmptyStateView,
+  InterruptedDescriptionView,
+  NonInterruptedDescriptionView,
+  ThreadStateView,
+} from "./views";
 
 interface StateViewRecursiveProps {
   value: unknown;
@@ -247,7 +254,6 @@ export function StateView({
   view,
 }: StateViewComponentProps) {
   const [expanded, setExpanded] = useState(false);
-
   const threadValues = threadData.thread.values;
   const description = threadData.interrupts?.[0]?.description;
   const isInterrupted =
@@ -256,31 +262,22 @@ export function StateView({
     threadData.interrupts.length > 0;
 
   if (!threadValues) {
-    return <div>No state found</div>;
+    return <EmptyStateView />;
   }
 
   return (
-    <div className="overflow-y-auto pl-6 border-t-[1px] lg:border-t-[0px] lg:border-l-[1px] border-gray-100 flex flex-row gap-0 w-full">
+    <div className="overflow-y-auto pl-6 border-t-[1px] lg:border-t-[0px] lg:border-l-[1px] border-gray-100 flex flex-row gap-0 w-full relative">
       {view === "description" && isInterrupted && (
-        <div className="pt-6 pb-2">
-          <MarkdownText className="text-wrap break-words whitespace-pre-wrap">
-            {description || "No description provided"}
-          </MarkdownText>
-        </div>
+        <InterruptedDescriptionView description={description} />
+      )}
+      {view === "description" && !isInterrupted && (
+        <NonInterruptedDescriptionView />
       )}
       {view === "state" && (
-        <div className="flex flex-col items-start justify-start gap-1 pt-6 pb-2">
-          {Object.entries(threadValues).map(([k, v], idx) => (
-            <StateViewObject
-              expanded={expanded}
-              key={`state-view-${k}-${idx}`}
-              keyName={k}
-              value={v}
-            />
-          ))}
-        </div>
+        <ThreadStateView threadValues={threadValues} expanded={expanded} />
       )}
-      <div className="flex gap-2 items-start justify-end pt-6 pr-6">
+
+      <div className="absolute top-6 right-6 flex gap-2">
         {view === "state" && (
           <Button
             onClick={() => setExpanded((prev) => !prev)}
@@ -295,7 +292,6 @@ export function StateView({
             )}
           </Button>
         )}
-
         <Button
           onClick={() => handleShowSidePanel(false, false)}
           variant="ghost"

--- a/src/components/agent-inbox/components/state-view.tsx
+++ b/src/components/agent-inbox/components/state-view.tsx
@@ -10,7 +10,6 @@ import { motion } from "framer-motion";
 import { cn } from "@/lib/utils";
 import { BaseMessage } from "@langchain/core/messages";
 import { ToolCall } from "@langchain/core/messages/tool";
-import React from "react";
 import { Button } from "../../ui/button";
 import { ToolCallTable } from "./tool-call-table";
 import { MarkdownText } from "@/components/ui/markdown-text";
@@ -256,12 +255,6 @@ export function StateView({
     threadData.interrupts &&
     threadData.interrupts.length > 0;
 
-  // Format dates for display
-  const createdAt = new Date(threadData.thread.created_at);
-  const updatedAt = new Date(threadData.thread.updated_at);
-  const formattedCreatedAt = createdAt.toLocaleString();
-  const formattedUpdatedAt = updatedAt.toLocaleString();
-
   if (!threadValues) {
     return <div>No state found</div>;
   }
@@ -273,61 +266,6 @@ export function StateView({
           <MarkdownText className="text-wrap break-words whitespace-pre-wrap">
             {description || "No description provided"}
           </MarkdownText>
-        </div>
-      )}
-      {view === "description" && !isInterrupted && (
-        <div className="pt-6 pb-2 w-full">
-          <h3 className="text-lg font-medium mb-4">Thread Information</h3>
-
-          <div className="grid grid-cols-1 gap-3">
-            <div>
-              <h4 className="text-sm font-semibold text-gray-700">Status</h4>
-              <div className="mt-1 flex items-center">
-                <div
-                  className={cn(
-                    "w-3 h-3 rounded-full mr-2",
-                    threadData.status === "idle"
-                      ? "bg-gray-400"
-                      : threadData.status === "busy"
-                        ? "bg-blue-500"
-                        : "bg-red-500"
-                  )}
-                ></div>
-                <p className="text-sm capitalize">{threadData.status}</p>
-              </div>
-            </div>
-
-            <div>
-              <h4 className="text-sm font-semibold text-gray-700">Thread ID</h4>
-              <p className="text-sm font-mono mt-1">
-                {threadData.thread.thread_id}
-              </p>
-            </div>
-
-            <div>
-              <h4 className="text-sm font-semibold text-gray-700">
-                Created At
-              </h4>
-              <p className="text-sm mt-1">{formattedCreatedAt}</p>
-            </div>
-
-            <div>
-              <h4 className="text-sm font-semibold text-gray-700">
-                Last Updated
-              </h4>
-              <p className="text-sm mt-1">{formattedUpdatedAt}</p>
-            </div>
-
-            <div className="mt-2">
-              <h4 className="text-sm font-semibold text-gray-700">
-                Thread State Summary
-              </h4>
-              <p className="text-sm mt-1 italic">
-                View the complete state in the &quot;State&quot; tab for
-                detailed information.
-              </p>
-            </div>
-          </div>
         </div>
       )}
       {view === "state" && (

--- a/src/components/agent-inbox/components/thread-actions-view.tsx
+++ b/src/components/agent-inbox/components/thread-actions-view.tsx
@@ -30,7 +30,6 @@ function ButtonGroup({
   handleShowDescription,
   showingState,
   showingDescription,
-  isInterrupted,
 }: {
   handleShowState: () => void;
   handleShowDescription: () => void;
@@ -43,9 +42,7 @@ function ButtonGroup({
       <Button
         variant="outline"
         className={cn(
-          isInterrupted
-            ? "rounded-l-md rounded-r-none border-r-[0px]"
-            : "rounded-md",
+          "rounded-l-md rounded-r-none border-r-[0px]",
           showingState ? "text-black" : "bg-white"
         )}
         size="sm"
@@ -53,19 +50,17 @@ function ButtonGroup({
       >
         State
       </Button>
-      {isInterrupted && (
-        <Button
-          variant="outline"
-          className={cn(
-            "rounded-l-none rounded-r-md border-l-[0px]",
-            showingDescription ? "text-black" : "bg-white"
-          )}
-          size="sm"
-          onClick={handleShowDescription}
-        >
-          Description
-        </Button>
-      )}
+      <Button
+        variant="outline"
+        className={cn(
+          "rounded-l-none rounded-r-md border-l-[0px]",
+          showingDescription ? "text-black" : "bg-white"
+        )}
+        size="sm"
+        onClick={handleShowDescription}
+      >
+        Description
+      </Button>
     </div>
   );
 }

--- a/src/components/agent-inbox/components/thread-actions-view.tsx
+++ b/src/components/agent-inbox/components/thread-actions-view.tsx
@@ -1,6 +1,6 @@
 import { Button } from "@/components/ui/button";
 import { Thread } from "@langchain/langgraph-sdk";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, RefreshCw, AlertTriangle, ClockIcon } from "lucide-react";
 import { HumanInterrupt, ThreadData } from "../types";
 import { constructOpenInStudioURL } from "../utils";
 import { ThreadIdCopyable } from "./thread-id";
@@ -12,15 +12,12 @@ import { useToast } from "@/hooks/use-toast";
 import { cn } from "@/lib/utils";
 import { useQueryParams } from "../hooks/use-query-params";
 import { useThreadsContext } from "../contexts/ThreadContext";
+import { useState } from "react";
 
 interface ThreadActionsViewProps<
   ThreadValues extends Record<string, any> = Record<string, any>,
 > {
-  threadData: {
-    thread: Thread<ThreadValues>;
-    status: "interrupted";
-    interrupts: HumanInterrupt[];
-  };
+  threadData: ThreadData<ThreadValues>;
   setThreadData: React.Dispatch<
     React.SetStateAction<ThreadData<ThreadValues> | undefined>
   >;
@@ -77,31 +74,29 @@ export function ThreadActionsView<
   showDescription,
   showState,
 }: ThreadActionsViewProps<ThreadValues>) {
-  const {
-    acceptAllowed,
-    hasEdited,
-    hasAddedResponse,
-    streaming,
-    supportsMultipleMethods,
-    streamFinished,
-    currentNode,
-    loading,
-    handleSubmit,
-    handleIgnore,
-    handleResolve,
-    setSelectedSubmitType,
-    setHasAddedResponse,
-    setHasEdited,
-    humanResponse,
-    setHumanResponse,
-    initialHumanInterruptEditValue,
-  } = useInterruptedActions<ThreadValues>({
-    threadData,
-    setThreadData,
-  });
   const { agentInboxes } = useThreadsContext<ThreadValues>();
   const { toast } = useToast();
   const { updateQueryParams } = useQueryParams();
+  const [refreshing, setRefreshing] = useState(false);
+
+  // Only use interrupted actions for interrupted threads
+  const isInterrupted =
+    threadData.status === "interrupted" &&
+    threadData.interrupts !== undefined &&
+    threadData.interrupts.length > 0;
+
+  // Initialize the hook outside of conditional to satisfy React rules of hooks
+  // Pass null values when not needed
+  const interruptedActions = useInterruptedActions<ThreadValues>({
+    threadData: isInterrupted
+      ? (threadData as {
+          thread: Thread<ThreadValues>;
+          status: "interrupted";
+          interrupts: HumanInterrupt[];
+        })
+      : (null as any),
+    setThreadData: isInterrupted ? setThreadData : (null as any),
+  });
 
   const deploymentUrl = agentInboxes.find((i) => i.selected)?.deploymentUrl;
 
@@ -122,10 +117,71 @@ export function ThreadActionsView<
     window.open(studioUrl, "_blank");
   };
 
+  const handleRefreshThread = async () => {
+    if (!deploymentUrl) {
+      toast({
+        title: "Error",
+        description: "Please set the LangGraph deployment URL in settings.",
+        duration: 5000,
+      });
+      return;
+    }
+
+    setRefreshing(true);
+    try {
+      toast({
+        title: "Refreshing thread",
+        description: "Checking for updates to the thread status...",
+        duration: 3000,
+      });
+
+      // In a real implementation, you would fetch the latest thread status here
+      // For now, we'll just simulate a refresh with a timeout
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+
+      toast({
+        title: "Thread refreshed",
+        description: "Thread information has been updated.",
+        duration: 3000,
+      });
+    } catch (_error) {
+      toast({
+        title: "Error",
+        description: "Failed to refresh thread information.",
+        variant: "destructive",
+        duration: 5000,
+      });
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
   const threadTitle =
-    threadData.interrupts[0]?.action_request?.action || "Unknown";
-  const actionsDisabled = loading || streaming;
-  const ignoreAllowed = threadData.interrupts[0].config.allow_ignore;
+    isInterrupted && threadData.interrupts
+      ? threadData.interrupts[0]?.action_request?.action || "Thread"
+      : `Thread (${threadData.status})`;
+
+  const actionsDisabled = isInterrupted
+    ? interruptedActions?.loading || interruptedActions?.streaming
+    : false;
+
+  const ignoreAllowed =
+    isInterrupted && threadData.interrupts
+      ? threadData.interrupts[0].config.allow_ignore
+      : false;
+
+  const getStatusIcon = () => {
+    switch (threadData.status) {
+      case "idle":
+        return <ClockIcon className="w-5 h-5 text-gray-500" />;
+      case "busy":
+        return <RefreshCw className="w-5 h-5 text-blue-500" />;
+      case "error":
+        return <AlertTriangle className="w-5 h-5 text-red-500" />;
+      default:
+        return null;
+    }
+  };
 
   return (
     <div className="flex flex-col min-h-full w-full p-12 gap-9">
@@ -139,7 +195,12 @@ export function ThreadActionsView<
           >
             <ArrowLeft className="w-5 h-5" />
           </TooltipIconButton>
-          <p className="text-2xl tracking-tighter text-pretty">{threadTitle}</p>
+          <div className="flex items-center gap-2">
+            {!isInterrupted && getStatusIcon()}
+            <p className="text-2xl tracking-tighter text-pretty">
+              {threadTitle}
+            </p>
+          </div>
           <ThreadIdCopyable threadId={threadData.thread.thread_id} />
         </div>
         <div className="flex flex-row gap-2 items-center justify-start">
@@ -162,45 +223,139 @@ export function ThreadActionsView<
         </div>
       </div>
 
-      <div className="flex flex-row gap-2 items-center justify-start w-full">
-        <Button
-          variant="outline"
-          className="text-gray-800 border-gray-500 font-normal bg-white"
-          onClick={handleResolve}
-          disabled={actionsDisabled}
-        >
-          Mark as Resolved
-        </Button>
-        {ignoreAllowed && (
-          <Button
-            variant="outline"
-            className="text-gray-800 border-gray-500 font-normal bg-white"
-            onClick={handleIgnore}
-            disabled={actionsDisabled}
-          >
-            Ignore
-          </Button>
-        )}
-      </div>
+      {/* Non-interrupted thread actions */}
+      {!isInterrupted && (
+        <div className="flex flex-col gap-6">
+          {/* Status-specific UI */}
+          {(threadData.status === "idle" || threadData.status === "busy") && (
+            <div className="flex flex-row gap-2 items-center justify-start w-full">
+              <Button
+                variant="outline"
+                className="text-gray-800 border-gray-500 font-normal bg-white flex items-center gap-2"
+                onClick={handleRefreshThread}
+                disabled={refreshing}
+              >
+                <RefreshCw
+                  className={cn("w-4 h-4", refreshing && "animate-spin")}
+                />
+                {refreshing ? "Refreshing..." : "Refresh Thread Status"}
+              </Button>
+            </div>
+          )}
 
-      {/* Actions */}
-      <InboxItemInput
-        acceptAllowed={acceptAllowed}
-        hasEdited={hasEdited}
-        hasAddedResponse={hasAddedResponse}
-        interruptValue={threadData.interrupts[0]}
-        humanResponse={humanResponse}
-        initialValues={initialHumanInterruptEditValue.current}
-        setHumanResponse={setHumanResponse}
-        streaming={streaming}
-        streamFinished={streamFinished}
-        currentNode={currentNode}
-        supportsMultipleMethods={supportsMultipleMethods}
-        setSelectedSubmitType={setSelectedSubmitType}
-        setHasAddedResponse={setHasAddedResponse}
-        setHasEdited={setHasEdited}
-        handleSubmit={handleSubmit}
-      />
+          {threadData.status === "error" && (
+            <div className="p-4 border border-red-200 bg-red-50 rounded-md">
+              <div className="flex items-start gap-3">
+                <AlertTriangle className="w-5 h-5 text-red-500 mt-0.5" />
+                <div>
+                  <h3 className="font-medium text-red-800">Error State</h3>
+                  <p className="text-sm text-red-700 mt-1">
+                    This thread is in an error state. You may need to check the
+                    logs or retry the operation.
+                  </p>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Thread information summary */}
+          <div className="flex flex-col gap-3 p-4 border border-gray-200 rounded-md bg-gray-50">
+            <h3 className="font-medium">Thread Details</h3>
+
+            <div className="grid grid-cols-2 gap-2 text-sm">
+              <div>
+                <span className="font-medium text-gray-700">Status:</span>
+                <span className="ml-2 capitalize">{threadData.status}</span>
+              </div>
+
+              <div>
+                <span className="font-medium text-gray-700">Created:</span>
+                <span className="ml-2">
+                  {new Date(threadData.thread.created_at).toLocaleString()}
+                </span>
+              </div>
+
+              <div>
+                <span className="font-medium text-gray-700">Last updated:</span>
+                <span className="ml-2">
+                  {new Date(threadData.thread.updated_at).toLocaleString()}
+                </span>
+              </div>
+
+              <div>
+                <span className="font-medium text-gray-700">ID:</span>
+                <span className="ml-2 font-mono text-xs">
+                  {threadData.thread.thread_id}
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <p className="text-sm text-gray-600">
+            View the thread state in the &quot;State&quot; tab for detailed
+            information about this thread.
+          </p>
+        </div>
+      )}
+
+      {isInterrupted && threadData.interrupts && (
+        <>
+          <div className="flex flex-row gap-2 items-center justify-start w-full">
+            <Button
+              variant="outline"
+              className="text-gray-800 border-gray-500 font-normal bg-white"
+              onClick={interruptedActions?.handleResolve}
+              disabled={actionsDisabled}
+            >
+              Mark as Resolved
+            </Button>
+            {ignoreAllowed && (
+              <Button
+                variant="outline"
+                className="text-gray-800 border-gray-500 font-normal bg-white"
+                onClick={interruptedActions?.handleIgnore}
+                disabled={actionsDisabled}
+              >
+                Ignore
+              </Button>
+            )}
+          </div>
+
+          {/* Actions */}
+          <InboxItemInput
+            acceptAllowed={interruptedActions?.acceptAllowed ?? false}
+            hasEdited={interruptedActions?.hasEdited ?? false}
+            hasAddedResponse={interruptedActions?.hasAddedResponse ?? false}
+            interruptValue={threadData.interrupts[0]}
+            humanResponse={
+              (interruptedActions?.humanResponse as any) || {
+                type: "accept",
+                args: null,
+              }
+            }
+            initialValues={
+              interruptedActions?.initialHumanInterruptEditValue.current || {}
+            }
+            setHumanResponse={
+              interruptedActions?.setHumanResponse ?? (() => {})
+            }
+            streaming={interruptedActions?.streaming ?? false}
+            streamFinished={interruptedActions?.streamFinished ?? false}
+            currentNode={interruptedActions?.currentNode ?? ""}
+            supportsMultipleMethods={
+              interruptedActions?.supportsMultipleMethods ?? false
+            }
+            setSelectedSubmitType={
+              interruptedActions?.setSelectedSubmitType ?? (() => {})
+            }
+            setHasAddedResponse={
+              interruptedActions?.setHasAddedResponse ?? (() => {})
+            }
+            setHasEdited={interruptedActions?.setHasEdited ?? (() => {})}
+            handleSubmit={interruptedActions?.handleSubmit ?? (async () => {})}
+          />
+        </>
+      )}
     </div>
   );
 }

--- a/src/components/agent-inbox/components/views/EmptyStateView.tsx
+++ b/src/components/agent-inbox/components/views/EmptyStateView.tsx
@@ -1,0 +1,7 @@
+interface EmptyStateViewProps {
+  // Component might be extended with additional props in the future
+}
+
+export function EmptyStateView({}: EmptyStateViewProps) {
+  return <div className="p-6 text-gray-500">No state found</div>;
+}

--- a/src/components/agent-inbox/components/views/InterruptedDescriptionView.tsx
+++ b/src/components/agent-inbox/components/views/InterruptedDescriptionView.tsx
@@ -1,0 +1,17 @@
+import { MarkdownText } from "@/components/ui/markdown-text";
+
+interface InterruptedDescriptionViewProps {
+  description: string | undefined;
+}
+
+export function InterruptedDescriptionView({
+  description,
+}: InterruptedDescriptionViewProps) {
+  return (
+    <div className="pt-6 pb-2">
+      <MarkdownText className="text-wrap break-words whitespace-pre-wrap">
+        {description || "No description provided"}
+      </MarkdownText>
+    </div>
+  );
+}

--- a/src/components/agent-inbox/components/views/NonInterruptedDescriptionView.tsx
+++ b/src/components/agent-inbox/components/views/NonInterruptedDescriptionView.tsx
@@ -1,0 +1,13 @@
+interface NonInterruptedDescriptionViewProps {
+  // Component might be extended with additional props in the future
+}
+
+export function NonInterruptedDescriptionView({}: NonInterruptedDescriptionViewProps) {
+  return (
+    <div className="pt-6 pb-2 w-full">
+      <p className="text-sm text-gray-500 italic">
+        This thread has no additional description.
+      </p>
+    </div>
+  );
+}

--- a/src/components/agent-inbox/components/views/ThreadStateView.tsx
+++ b/src/components/agent-inbox/components/views/ThreadStateView.tsx
@@ -1,0 +1,26 @@
+import { StateViewObject } from "../state-view";
+
+interface ThreadStateViewProps {
+  threadValues: Record<string, any>;
+  expanded?: boolean;
+}
+
+export function ThreadStateView({
+  threadValues,
+  expanded,
+}: ThreadStateViewProps) {
+  return (
+    <div className="flex-1 w-full">
+      <div className="flex flex-col items-start justify-start gap-1 pt-6 pb-2">
+        {Object.entries(threadValues).map(([k, v], idx) => (
+          <StateViewObject
+            expanded={expanded}
+            key={`state-view-${k}-${idx}`}
+            keyName={k}
+            value={v}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/agent-inbox/components/views/index.ts
+++ b/src/components/agent-inbox/components/views/index.ts
@@ -1,0 +1,4 @@
+export * from "./InterruptedDescriptionView";
+export * from "./NonInterruptedDescriptionView";
+export * from "./EmptyStateView";
+export * from "./ThreadStateView";

--- a/src/components/agent-inbox/hooks/use-interrupted-actions.tsx
+++ b/src/components/agent-inbox/hooks/use-interrupted-actions.tsx
@@ -401,10 +401,10 @@ export default function useInterruptedActions<
     loading,
     threadId: threadData?.thread.thread_id || "",
     isIgnoreAllowed: threadData?.interrupts?.[0]?.config.allow_ignore || false,
-    supportsMultipleMethods: !!(
-      threadData?.interrupts?.[0]?.config.allow_respond &&
-      threadData?.interrupts?.[0]?.config.allow_edit
-    ),
+    supportsMultipleMethods:
+      humanResponse.filter(
+        (r) => r.type === "edit" || r.type === "accept" || r.type === "response"
+      ).length > 1,
     selectedSubmitType,
     hasEdited,
     hasAddedResponse,

--- a/src/components/agent-inbox/thread-view.tsx
+++ b/src/components/agent-inbox/thread-view.tsx
@@ -14,7 +14,7 @@ export function ThreadView<
   const { threadData: threads, loading } = useThreadsContext<ThreadValues>();
   const [threadData, setThreadData] =
     React.useState<ThreadData<ThreadValues>>();
-  const [showDescription, setShowDescription] = React.useState(true);
+  const [showDescription, setShowDescription] = React.useState(false);
   const [showState, setShowState] = React.useState(false);
   const showSidePanel = showDescription || showState;
 
@@ -27,6 +27,12 @@ export function ThreadView<
       );
       if (selectedThread) {
         setThreadData(selectedThread);
+        // Only show description tab by default for interrupted threads
+        const isInterrupted =
+          selectedThread.status === "interrupted" &&
+          selectedThread.interrupts !== undefined &&
+          selectedThread.interrupts.length > 0;
+        setShowDescription(isInterrupted);
         return;
       } else {
         // Route the user back to the inbox view.

--- a/src/components/agent-inbox/thread-view.tsx
+++ b/src/components/agent-inbox/thread-view.tsx
@@ -27,12 +27,8 @@ export function ThreadView<
       );
       if (selectedThread) {
         setThreadData(selectedThread);
-        // Only show description tab by default for interrupted threads
-        const isInterrupted =
-          selectedThread.status === "interrupted" &&
-          selectedThread.interrupts !== undefined &&
-          selectedThread.interrupts.length > 0;
-        setShowDescription(isInterrupted);
+        // Keep description hidden by default
+        setShowDescription(false);
         return;
       } else {
         // Route the user back to the inbox view.

--- a/src/components/agent-inbox/thread-view.tsx
+++ b/src/components/agent-inbox/thread-view.tsx
@@ -1,8 +1,7 @@
-import { Thread } from "@langchain/langgraph-sdk";
 import { StateView } from "./components/state-view";
 import { ThreadActionsView } from "./components/thread-actions-view";
 import { useThreadsContext } from "./contexts/ThreadContext";
-import { HumanInterrupt, ThreadData } from "./types";
+import { ThreadData } from "./types";
 import React from "react";
 import { cn } from "@/lib/utils";
 import { useQueryParams } from "./hooks/use-query-params";
@@ -58,12 +57,7 @@ export function ThreadView<
     }
   };
 
-  if (
-    !threadData ||
-    threadData.status !== "interrupted" ||
-    !threadData.interrupts ||
-    threadData.interrupts.length === 0
-  ) {
+  if (!threadData) {
     return null;
   }
 
@@ -76,13 +70,7 @@ export function ThreadView<
         )}
       >
         <ThreadActionsView<ThreadValues>
-          threadData={
-            threadData as {
-              thread: Thread<ThreadValues>;
-              status: "interrupted";
-              interrupts: HumanInterrupt[];
-            }
-          }
+          threadData={threadData}
           setThreadData={setThreadData}
           handleShowSidePanel={handleShowSidePanel}
           showState={showState}


### PR DESCRIPTION
fixes #49 

#  Improve Thread Viewing and Fix Breadcrumb Layout Shift

This PR addresses two key improvements to the Agent Inbox UI:


## Thread Viewing Improvements
- Enhanced support for viewing non-interrupted threads
- Improved thread selection and navigation flow
- Updated thread context handling to properly display threads without human interrupts


## Breadcrumb Layout Stability
- Fixed layout shift issue with breadcrumb navigation by adding a placeholder element with matching dimensions when data is loading
- Maintains consistent 34px height during page transitions and refreshes
- Added appropriate ARIA attributes to ensure accessibility

These changes provide a more stable UI experience during page loads and transitions while expanding the application's capability to handle different thread states effectively.
