### PR TITLE
Dylan/fix studio urls fixes 51

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,13 +217,17 @@ function myGraphFunction(state: MyGraphState) {
 
 Common issues and solutions:
 
-1. **Connection Issues**
-   - Verify your `LANGSMITH_API_KEY` is set correctly
-   - Ensure your Deployment URL is accessible
-   - Check if your LangGraph deployment is running
+### Connection Issues
+ - Verify your `LANGSMITH_API_KEY` is set correctly
+ - Ensure your Deployment URL is accessible
+ - Check if your LangGraph deployment is running
 
-2. **Schema Validation Errors**
-   - Ensure all required fields are present in your interrupt objects
-   - Verify the types of all fields match the schema
-   - Check that response handling matches expected types
-   - Check you're extracting the first object from the response list returned by the `interrupt` function
+### Schema Validation Errors
+ - Ensure all required fields are present in your interrupt objects
+ - Verify the types of all fields match the schema
+ - Check that response handling matches expected types
+ - Check you're extracting the first object from the response list returned by the `interrupt` function
+
+### The Open in Studio button doesn't work for my deployed graphs
+ - This feature requires fields from your LangGraph deployment only made available after **04/18/2025**. If your graph *has not* created a new revision since then, you will need to create a new revision for this feature to work.
+ - Delete the inbox, and re-add it. The logic for capturing the required fields to construct the Studio URL is new, and your inbox will need to be re-added for this feature to work.

--- a/src/components/agent-inbox/components/generic-inbox-item.tsx
+++ b/src/components/agent-inbox/components/generic-inbox-item.tsx
@@ -9,7 +9,10 @@ import { constructOpenInStudioURL } from "../utils";
 import { Button } from "@/components/ui/button";
 import { useThreadsContext } from "../contexts/ThreadContext";
 import { useQueryParams } from "../hooks/use-query-params";
-import { VIEW_STATE_THREAD_QUERY_PARAM } from "../constants";
+import {
+  STUDIO_NOT_WORKING_TROUBLESHOOTING_URL,
+  VIEW_STATE_THREAD_QUERY_PARAM,
+} from "../constants";
 
 interface GenericInboxItemProps<
   ThreadValues extends Record<string, any> = Record<string, any>,
@@ -50,10 +53,26 @@ export function GenericInboxItem<
     if (studioUrl === "#") {
       toast({
         title: "Error",
-        description:
-          "Could not construct Studio URL. Check if inbox has necessary details (Project ID, Tenant ID).",
+        description: (
+          <>
+            <p>
+              Could not construct Studio URL. Check if inbox has necessary
+              details (Project ID, Tenant ID).
+            </p>
+            <p>
+              If the issue persists, see the{" "}
+              <a
+                href={STUDIO_NOT_WORKING_TROUBLESHOOTING_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                troubleshooting section
+              </a>
+            </p>
+          </>
+        ),
         variant: "destructive",
-        duration: 5000,
+        duration: 10000,
       });
     } else {
       window.open(studioUrl, "_blank");

--- a/src/components/agent-inbox/components/generic-inbox-item.tsx
+++ b/src/components/agent-inbox/components/generic-inbox-item.tsx
@@ -7,7 +7,6 @@ import { format } from "date-fns";
 import { useToast } from "@/hooks/use-toast";
 import { constructOpenInStudioURL } from "../utils";
 import { Button } from "@/components/ui/button";
-import NextLink from "next/link";
 import { useThreadsContext } from "../contexts/ThreadContext";
 import { useQueryParams } from "../hooks/use-query-params";
 import { VIEW_STATE_THREAD_QUERY_PARAM } from "../constants";
@@ -30,23 +29,35 @@ export function GenericInboxItem<
   const { toast } = useToast();
   const { updateQueryParams } = useQueryParams();
 
-  const deploymentUrl = agentInboxes.find((i) => i.selected)?.deploymentUrl;
+  const selectedInbox = agentInboxes.find((i) => i.selected);
 
   const handleOpenInStudio = () => {
-    if (!deploymentUrl) {
+    if (!selectedInbox) {
       toast({
         title: "Error",
-        description: "Please set the LangGraph deployment URL in settings.",
+        description: "No agent inbox selected.",
+        variant: "destructive",
         duration: 5000,
       });
       return;
     }
 
     const studioUrl = constructOpenInStudioURL(
-      deploymentUrl,
+      selectedInbox,
       threadData.thread.thread_id
     );
-    window.open(studioUrl, "_blank");
+
+    if (studioUrl === "#") {
+      toast({
+        title: "Error",
+        description:
+          "Could not construct Studio URL. Check if inbox has necessary details (Project ID, Tenant ID).",
+        variant: "destructive",
+        duration: 5000,
+      });
+    } else {
+      window.open(studioUrl, "_blank");
+    }
   };
 
   const updatedAtDateString = format(
@@ -70,40 +81,36 @@ export function GenericInboxItem<
       <div
         className={cn(
           "flex items-center justify-start gap-2",
-          deploymentUrl ? "col-span-7" : "col-span-9"
+          selectedInbox ? "col-span-7" : "col-span-9"
         )}
       >
         <p className="text-black text-sm font-semibold">Thread ID:</p>
         <ThreadIdCopyable showUUID threadId={threadData.thread.thread_id} />
       </div>
 
-      {deploymentUrl && (
+      {selectedInbox && (
         <div className="col-span-2">
-          <NextLink
-            href={constructOpenInStudioURL(
-              deploymentUrl,
-              threadData.thread.thread_id
-            )}
-            target="_blank"
-            rel="noopener noreferrer"
+          <Button
+            size="sm"
+            variant="outline"
+            className="flex items-center gap-1 bg-white"
+            onClick={handleOpenInStudio}
           >
-            <Button
-              size="sm"
-              variant="outline"
-              className="flex items-center gap-1 bg-white"
-              onClick={handleOpenInStudio}
-            >
-              Studio
-            </Button>
-          </NextLink>
+            Studio
+          </Button>
         </div>
       )}
 
-      <div className="col-span-2">
+      <div className={cn("col-span-2", !selectedInbox && "col-start-10")}>
         <InboxItemStatuses status={threadData.status} />
       </div>
 
-      <p className="col-span-1 text-gray-600 font-light text-sm">
+      <p
+        className={cn(
+          "col-span-1 text-gray-600 font-light text-sm",
+          !selectedInbox && "col-start-12"
+        )}
+      >
         {updatedAtDateString}
       </p>
     </div>

--- a/src/components/agent-inbox/components/thread-actions-view.tsx
+++ b/src/components/agent-inbox/components/thread-actions-view.tsx
@@ -80,6 +80,9 @@ export function ThreadActionsView<
   const { updateQueryParams } = useQueryParams();
   const [refreshing, setRefreshing] = useState(false);
 
+  // Get the selected inbox object
+  const selectedInbox = agentInboxes.find((i) => i.selected);
+
   // Only use interrupted actions for interrupted threads
   const isInterrupted =
     threadData.status === "interrupted" &&
@@ -99,30 +102,43 @@ export function ThreadActionsView<
     setThreadData: isInterrupted ? setThreadData : null,
   });
 
-  const deploymentUrl = agentInboxes.find((i) => i.selected)?.deploymentUrl;
-
   const handleOpenInStudio = () => {
-    if (!deploymentUrl) {
+    if (!selectedInbox) {
       toast({
         title: "Error",
-        description: "Please set the LangGraph deployment URL in settings.",
+        description: "No agent inbox selected.",
+        variant: "destructive",
         duration: 5000,
       });
       return;
     }
 
     const studioUrl = constructOpenInStudioURL(
-      deploymentUrl,
+      selectedInbox, // Pass the full inbox object
       threadData.thread.thread_id
     );
-    window.open(studioUrl, "_blank");
+
+    if (studioUrl === "#") {
+      // Handle case where URL construction failed (e.g., missing data)
+      toast({
+        title: "Error",
+        description:
+          "Could not construct Studio URL. Check if inbox has necessary details (Project ID, Tenant ID).",
+        variant: "destructive",
+        duration: 5000,
+      });
+    } else {
+      window.open(studioUrl, "_blank");
+    }
   };
 
   const handleRefreshThread = async () => {
-    if (!deploymentUrl) {
+    // Use selectedInbox here as well
+    if (!selectedInbox) {
       toast({
         title: "Error",
-        description: "Please set the LangGraph deployment URL in settings.",
+        description: "No agent inbox selected.",
+        variant: "destructive",
         duration: 5000,
       });
       return;
@@ -232,7 +248,7 @@ export function ThreadActionsView<
           <ThreadIdCopyable threadId={threadData.thread.thread_id} />
         </div>
         <div className="flex flex-row gap-2 items-center justify-start">
-          {deploymentUrl && (
+          {selectedInbox && (
             <Button
               size="sm"
               variant="outline"

--- a/src/components/agent-inbox/components/thread-actions-view.tsx
+++ b/src/components/agent-inbox/components/thread-actions-view.tsx
@@ -6,7 +6,10 @@ import { ThreadIdCopyable } from "./thread-id";
 import { InboxItemInput } from "./inbox-item-input";
 import useInterruptedActions from "../hooks/use-interrupted-actions";
 import { TooltipIconButton } from "@/components/ui/assistant-ui/tooltip-icon-button";
-import { VIEW_STATE_THREAD_QUERY_PARAM } from "../constants";
+import {
+  STUDIO_NOT_WORKING_TROUBLESHOOTING_URL,
+  VIEW_STATE_THREAD_QUERY_PARAM,
+} from "../constants";
 import { useToast } from "@/hooks/use-toast";
 import { cn } from "@/lib/utils";
 import { useQueryParams } from "../hooks/use-query-params";
@@ -122,10 +125,26 @@ export function ThreadActionsView<
       // Handle case where URL construction failed (e.g., missing data)
       toast({
         title: "Error",
-        description:
-          "Could not construct Studio URL. Check if inbox has necessary details (Project ID, Tenant ID).",
+        description: (
+          <>
+            <p>
+              Could not construct Studio URL. Check if inbox has necessary
+              details (Project ID, Tenant ID).
+            </p>
+            <p>
+              If the issue persists, see the{" "}
+              <a
+                href={STUDIO_NOT_WORKING_TROUBLESHOOTING_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                troubleshooting section
+              </a>
+            </p>
+          </>
+        ),
         variant: "destructive",
-        duration: 5000,
+        duration: 10000,
       });
     } else {
       window.open(studioUrl, "_blank");

--- a/src/components/agent-inbox/constants.ts
+++ b/src/components/agent-inbox/constants.ts
@@ -8,3 +8,4 @@ export const AGENT_INBOX_PARAM = "agent_inbox";
 export const NO_INBOXES_FOUND_PARAM = "no_inboxes_found";
 export const AGENT_INBOX_GITHUB_README_URL =
   "https://github.com/langchain-ai/agent-inbox/blob/main/README.md";
+export const STUDIO_NOT_WORKING_TROUBLESHOOTING_URL = `${AGENT_INBOX_GITHUB_README_URL}#the-open-in-studio-button-doesnt-work-for-my-deployed-graphs`;

--- a/src/components/agent-inbox/types.ts
+++ b/src/components/agent-inbox/types.ts
@@ -95,4 +95,5 @@ export interface AgentInbox {
    * The tenant ID for the deployment (only for deployed graphs).
    */
   tenantId?: string;
+  createdAt: string;
 }

--- a/src/components/agent-inbox/utils.ts
+++ b/src/components/agent-inbox/utils.ts
@@ -133,19 +133,11 @@ export function constructOpenInStudioURL(
       return "#"; // Return a placeholder/non-functional link
     }
   } else {
-    // --- Existing logic for local/non-deployed URLs ---
-    // TODO: Review if this logic is still appropriate for local development.
-    // Currently appends `baseUrl` and `threadId` to the path.
-    // This might be incorrect if the intention is different for local.
+    // --- Logic for local/non-deployed URLs ---
     const smithStudioURL = new URL(smithStudioBaseUrl);
-    // trim the trailing slash from deploymentUrl
     const trimmedDeploymentUrl = inbox.deploymentUrl.replace(/\/$/, "");
 
     if (threadId) {
-      // The original logic appended threadId to the path, which might be wrong.
-      // Let's try adding it as a query param for now, similar to deployed.
-      // Revisit if local URLs need a different structure.
-      // smithStudioURL.pathname += `/${threadId}`; // Original way
       smithStudioURL.searchParams.append("threadId", threadId);
     }
 

--- a/src/components/agent-inbox/utils.ts
+++ b/src/components/agent-inbox/utils.ts
@@ -8,6 +8,7 @@ import {
   AgentInbox,
 } from "./types";
 import { logger } from "./utils/logger";
+import { validate } from "uuid";
 
 export function prettifyText(action: string) {
   return startCase(action.replace(/_/g, " "));
@@ -329,10 +330,8 @@ export function extractProjectId(inboxId: string): string | null {
   }
   const parts = inboxId.split(":");
   if (parts.length === 2) {
-    // Basic check if the first part looks like a UUID v4
-    const uuidV4Regex =
-      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-    if (uuidV4Regex.test(parts[0])) {
+    // Ensure the first part is a valid UUID
+    if (validate(parts[0])) {
       return parts[0];
     }
   }


### PR DESCRIPTION
fixes #51 


**Refactor: Update LangSmith Studio URL Construction for Deployed Graphs**

This PR updates how "Open in Studio" URLs are generated for deployed LangGraph instances to align with the new format required by LangSmith Studio (`/studio/thread?organizationId=...&hostProjectId=...&threadId=...`).

**Changes:**

*   Added `tenantId` to the `AgentInbox` type (`src/components/agent-inbox/types.ts`).
*   Updated the "Add Inbox" dialog (`src/components/agent-inbox/components/add-agent-inbox-dialog.tsx`) to fetch and store the `tenantId` from the deployment's `/info` endpoint.
*   Added a utility (`extractProjectId`) to parse the project ID from the `AgentInbox.id` for deployed graphs (`src/components/agent-inbox/utils.ts`).
*   Modified `constructOpenInStudioURL` (`src/components/agent-inbox/utils.ts`) to use `tenantId` and `projectId` for deployed graph URLs and accept the full `AgentInbox` object.
*   Updated `GenericInboxItem` (`src/components/agent-inbox/components/generic-inbox-item.tsx`) and `ThreadActionsView` (`src/components/agent-inbox/components/thread-actions-view.tsx`) to pass the `AgentInbox` object to the utility.
*   Fixed a bug in `GenericInboxItem` where a `NextLink` wrapper caused double navigation attempts for the Studio button.

**Result:**

Users can now correctly open threads associated with deployed LangGraph instances directly in LangSmith Studio using the "Studio" button within the Agent Inbox component. Error handling is included for cases where necessary data (`tenantId`, `projectId`) might be missing.

