### PR TITLE
fix-bug: 1 deployment, same graphs, weren't updating threads on switch

### DIFF
--- a/src/components/app-sidebar/index.tsx
+++ b/src/components/app-sidebar/index.tsx
@@ -90,7 +90,7 @@ export function AppSidebar() {
                         <Tooltip delayDuration={200}>
                           <TooltipTrigger asChild>
                             <SidebarMenuButton
-                              onClick={() => changeAgentInbox(item.id)}
+                              onClick={() => changeAgentInbox(item.id, true)}
                             >
                               {isDeployed ? (
                                 <UploadCloud className="w-5 h-5 text-blue-500" />


### PR DESCRIPTION
Fix bug where 2 graphs on the same deployment were not refreshing the threads properly, by passing replaceAll:true to the changeInbox handler.