### PR TITLE
UI improvements: support for more data types, auto-refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ cd agent-inbox
 yarn install
 ```
 
+Start up the web server:
+
+```bash
+yarn dev
+```
+
 ## Configuration
 
 Once up and running, you'll need to take two actions so that the Agent Inbox can connect to your LangGraph deployment.

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "react-json-view": "^1.21.3",
     "react-markdown": "^9.0.1",
     "react-syntax-highlighter": "^15.5.0",
+    "react-textarea-autosize": "^8.5.9",
     "rehype-katex": "^7.0.1",
     "rehype-raw": "^7.0.0",
     "remark-gfm": "^4.0.0",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -151,6 +151,26 @@ a {
   body {
     @apply bg-background text-foreground;
   }
+
+  /* Reintroduce some native element spacing & list styles while keeping Tailwind utilities.
+     This softens the effect of Preflight without disabling it entirely. */
+  h1, h2, h3, h4, h5, h6,
+  p,
+  ul, ol,
+  blockquote {
+    margin: revert; /* Restore default top/bottom margins */
+  }
+
+  ul, ol {
+    padding: revert; /* Restore left padding */
+    list-style: revert; /* Bring back bullets / numbers */
+  }
+
+  blockquote {
+    all: revert; /* Restore default quotation styling */
+    font-style: italic; /* Keep a bit of emphasis */
+    padding: 0 1rem; /* Gentle horizontal inset */
+  }
 }
 
 /* Change highlight color */
@@ -184,4 +204,23 @@ a {
 
 tr {
   height: var(--row-height);
+}
+
+/* Global table borders */
+@layer base {
+  table {
+    border-collapse: collapse; /* Ensure single borders */
+    width: 100%;
+    border: 1px solid hsl(var(--border));
+  }
+  th, td {
+    border: 1px solid hsl(var(--border));
+    padding: 0.5rem 0.75rem;
+    vertical-align: top;
+  }
+  th {
+    background: hsl(var(--muted));
+    font-weight: 600;
+    text-align: left;
+  }
 }

--- a/src/components/agent-inbox/components/settings-popover.tsx
+++ b/src/components/agent-inbox/components/settings-popover.tsx
@@ -27,7 +27,8 @@ export function SettingsPopover() {
   const [langchainApiKey, setLangchainApiKey] = React.useState("");
   const { getItem, setItem } = useLocalStorage();
   const { getSearchParam } = useQueryParams();
-  const { fetchThreads } = useThreadsContext();
+  const { fetchThreads, autoRefreshEnabled, toggleAutoRefresh } =
+    useThreadsContext();
   const [isRunningBackfill, setIsRunningBackfill] = React.useState(false);
   const [backfillCompleted, setBackfillCompleted] = React.useState(true);
   const { toast } = useToast();
@@ -50,6 +51,10 @@ export function SettingsPopover() {
       logger.error("Error getting/setting LangSmith API key", e);
     }
   }, [langchainApiKey]);
+
+  const handleToggleAutoRefresh = (e: React.ChangeEvent<HTMLInputElement>) => {
+    toggleAutoRefresh(e.target.checked);
+  };
 
   const handleChangeLangChainApiKey = (
     e: React.ChangeEvent<HTMLInputElement>
@@ -146,6 +151,24 @@ export function SettingsPopover() {
                 value={langchainApiKey}
                 onChange={handleChangeLangChainApiKey}
               />
+            </div>
+            <div className="flex flex-col items-start gap-2 w-full border-t pt-4">
+              <div className="flex flex-col gap-1 w-full items-start">
+                <Label htmlFor="auto-refresh-toggle">Auto Refresh</Label>
+                <p className="text-xs text-muted-foreground">Automatically poll the selected inbox for new threads.</p>
+              </div>
+              <div className="flex items-center gap-2">
+                <input
+                  id="auto-refresh-toggle"
+                  type="checkbox"
+                  className="h-4 w-4"
+                  checked={autoRefreshEnabled}
+                  onChange={handleToggleAutoRefresh}
+                />
+                <span className="text-sm text-muted-foreground">
+                  {autoRefreshEnabled ? "Enabled" : "Disabled"}
+                </span>
+              </div>
             </div>
             {!backfillCompleted && (
               <div className="flex flex-col items-start gap-2 w-full border-t pt-4">

--- a/src/components/agent-inbox/components/views/InterruptedDescriptionView.tsx
+++ b/src/components/agent-inbox/components/views/InterruptedDescriptionView.tsx
@@ -9,7 +9,7 @@ export function InterruptedDescriptionView({
 }: InterruptedDescriptionViewProps) {
   return (
     <div className="pt-6 pb-2">
-      <MarkdownText className="text-wrap break-words whitespace-pre-wrap">
+      <MarkdownText className="text-wrap break-words">
         {description || "No description provided"}
       </MarkdownText>
     </div>

--- a/src/components/agent-inbox/inbox-view.tsx
+++ b/src/components/agent-inbox/inbox-view.tsx
@@ -22,7 +22,7 @@ export function AgentInboxView<
   ThreadValues extends Record<string, any> = Record<string, any>,
 >({ saveScrollPosition, containerRef }: AgentInboxViewProps<ThreadValues>) {
   const { searchParams, updateQueryParams, getSearchParam } = useQueryParams();
-  const { loading, threadData, agentInboxes, clearThreadData } =
+  const { loading, threadData, agentInboxes, clearThreadData, fetchAttemptCount } =
     useThreadsContext<ThreadValues>();
   const selectedInbox = (getSearchParam(INBOX_PARAM) ||
     "interrupted") as ThreadStatusWithAll;
@@ -152,6 +152,9 @@ export function AgentInboxView<
     [selectedInbox, threadData]
   );
   const noThreadsFound = !threadDataToRender.length;
+  // We only want to show the pure loading empty state before the first fetch attempt has completed.
+  // After at least one attempt, if there are still no threads, show the empty state instead of a spinner.
+  const showInitialLoadingEmpty = noThreadsFound && loading && fetchAttemptCount === 0;
 
   // Correct way to save scroll position before navigation
   const handleThreadClick = () => {
@@ -205,7 +208,7 @@ export function AgentInboxView<
             />
           );
         })}
-        {noThreadsFound && !loading && (
+  {noThreadsFound && (!loading || fetchAttemptCount > 0) && (
           <div className="w-full flex items-center justify-center p-4 flex-col">
             <div className="flex gap-2 items-center justify-center text-gray-700 mb-4">
               <InboxIcon className="w-6 h-6" />
@@ -213,7 +216,7 @@ export function AgentInboxView<
             </div>
           </div>
         )}
-        {noThreadsFound && loading && (
+  {showInitialLoadingEmpty && (
           <div className="w-full flex items-center justify-center p-4">
             <div className="flex gap-2 items-center justify-center text-gray-700">
               <p className="font-medium">Loading</p>

--- a/src/components/ui/tag-input.tsx
+++ b/src/components/ui/tag-input.tsx
@@ -1,0 +1,136 @@
+import * as React from "react";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import { X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export interface TagInputProps {
+  value: string[];
+  onChange: (next: string[]) => void;
+  placeholder?: string;
+  disabled?: boolean;
+  allowDuplicates?: boolean;
+  className?: string;
+  maxItems?: number;
+  validateItem?: (item: string) => string | null; // return error message or null
+}
+
+/**
+ * A lightweight controlled component for editing a list of strings.
+ * - Type and press Enter or comma to add
+ * - Backspace with empty input removes last item
+ * - Click x to remove specific item
+ */
+export const TagInput: React.FC<TagInputProps> = ({
+  value,
+  onChange,
+  placeholder = "Add item…",
+  disabled,
+  allowDuplicates = false,
+  className,
+  maxItems,
+  validateItem,
+}) => {
+  const [draft, setDraft] = React.useState("");
+  const [error, setError] = React.useState<string | null>(null);
+  const inputRef = React.useRef<HTMLInputElement | null>(null);
+
+  const add = (raw: string) => {
+    const tag = raw.trim();
+    if (!tag) return;
+    if (maxItems && value.length >= maxItems) return;
+    if (!allowDuplicates && value.includes(tag)) {
+      setDraft("");
+      return;
+    }
+    if (validateItem) {
+      const err = validateItem(tag);
+      if (err) {
+        setError(err);
+        return;
+      }
+    }
+    setError(null);
+    onChange([...value, tag]);
+    setDraft("");
+  };
+
+  const remove = (idx: number) => {
+    setError(null);
+    const next = value.filter((_, i) => i !== idx);
+    onChange(next);
+  };
+
+  const onKeyDown: React.KeyboardEventHandler<HTMLInputElement> = (e) => {
+    if (e.key === "Enter" || e.key === ",") {
+      e.preventDefault();
+      add(draft);
+    } else if (e.key === "Backspace" && draft === "" && value.length > 0) {
+      remove(value.length - 1);
+    }
+  };
+
+  const onPaste: React.ClipboardEventHandler<HTMLInputElement> = (e) => {
+    const text = e.clipboardData.getData("text");
+    if (text.includes("\n") || text.includes(",")) {
+      e.preventDefault();
+      text
+        .split(/[\n,]/)
+        .map((t) => t.trim())
+        .filter(Boolean)
+        .forEach(add);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-1 w-full">
+      <div
+        className={cn(
+          "flex flex-wrap gap-2 rounded-md border border-input bg-transparent p-2 focus-within:ring-1 focus-within:ring-ring min-h-[42px] cursor-text",
+          disabled && "opacity-60 cursor-not-allowed",
+          error && "border-destructive focus-within:ring-destructive",
+          className
+        )}
+        onClick={() => inputRef.current?.focus()}
+      >
+        {value.map((tag, i) => (
+          <Badge
+            key={`${tag}-${i}`}
+            variant="secondary"
+            className="flex items-center gap-1 pr-1"
+          >
+            <span className="max-w-[160px] truncate" title={tag}>
+              {tag}
+            </span>
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                remove(i);
+              }}
+              aria-label={`Remove ${tag}`}
+              className="rounded hover:bg-muted/60 p-0.5 focus:outline-none focus:ring-1 focus:ring-ring"
+              disabled={disabled}
+            >
+              <X className="w-3 h-3" />
+            </button>
+          </Badge>
+        ))}
+        <Input
+          ref={inputRef}
+          disabled={disabled || (maxItems !== undefined && value.length >= maxItems)}
+          value={draft}
+            placeholder={value.length === 0 ? placeholder : ""}
+          onChange={(e) => {
+            setError(null);
+            setDraft(e.target.value);
+          }}
+          onKeyDown={onKeyDown}
+          onPaste={onPaste}
+          className="flex-1 min-w-[120px] border-0 shadow-none px-0 py-0 h-auto focus-visible:ring-0 focus-visible:outline-none text-sm"
+        />
+      </div>
+      {error && <p className="text-xs text-destructive">{error}</p>}
+    </div>
+  );
+};

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,20 +1,38 @@
 import * as React from "react";
-
 import { cn } from "@/lib/utils";
+import TextareaAutosize, {
+  type TextareaAutosizeProps,
+} from "react-textarea-autosize";
 
 export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+  extends Omit<TextareaAutosizeProps, "minRows" | "maxRows"> {
+  minRows?: number;
+  maxRows?: number;
+}
 
+// We keep the same exported name so existing imports continue working.
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
-  ({ className, ...props }, ref) => {
+  (
+    {
+      className,
+  minRows: incomingMinRows,
+  maxRows: incomingMaxRows,
+      ...rest
+    },
+    ref
+  ) => {
+  const minRows = incomingMinRows ?? 2; // default starting height
+  const maxRows = incomingMaxRows ?? 16;
     return (
-      <textarea
+      <TextareaAutosize
         className={cn(
-          "flex min-h-[60px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+          "flex w-full resize-none rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         ref={ref}
-        {...props}
+        minRows={minRows}
+        maxRows={maxRows}
+        {...rest}
       />
     );
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6572,6 +6572,15 @@ react-textarea-autosize@^8.3.2, react-textarea-autosize@^8.5.4:
     use-composed-ref "^1.3.0"
     use-latest "^1.2.1"
 
+react-textarea-autosize@^8.5.9:
+  version "8.5.9"
+  resolved "https://registry.yarnpkg.com/react-textarea-autosize/-/react-textarea-autosize-8.5.9.tgz#ab8627b09aa04d8a2f45d5b5cd94c84d1d4a8893"
+  integrity sha512-U1DGlIQN5AwgjTyOEnI1oCcMuEr1pv1qOtklB2l4nyMGbHzWrI0eFsYK0zos2YWqAolJyG0IWJaqWmWj5ETh0A==
+  dependencies:
+    "@babel/runtime" "^7.20.13"
+    use-composed-ref "^1.3.0"
+    use-latest "^1.2.1"
+
 react@^18:
   version "18.3.1"
   resolved "https://registry.yarnpkg.com/react/-/react-18.3.1.tgz#49ab892009c53933625bd16b2533fc754cab2891"


### PR DESCRIPTION
This pull request introduces several improvements to the Agent Inbox:

* Auto-refresh of inbox when new thread exists
* Handling of more data types for the form: booleans (radio), null (empty text), and lists of strings (a fancy component which acts like the "labels" editor on GitHub)
* Reset the reset-CSS for the right-hand side description, so that the descriptions can render better with richer markdown (bullets, tables, etc). The tailwind reset CSS was making the descriptions hard to read.

I realize this is a lot of improvements at once - once I started customizing, I didn't stop! But I can separate the PR into multiple, or only send PRs for certain features, whatever you'd prefer.

Screenshot of form with more data types:

<img width="571" height="884" alt="Screenshot 2025-09-11 at 4 09 07 PM" src="https://github.com/user-attachments/assets/83b53617-7b76-45bd-b188-5abca0ac66b8" />


Here's the AI-generated breakdown of the changes:

**UI/UX Improvements:**

* Restored default spacing and list styles for headings, paragraphs, lists, and blockquotes in `globals.css`, softening Tailwind's Preflight reset for better readability. Table styling is also standardized with global borders and background for headers. [[1]](diffhunk://#diff-4f206759c961f544a48464ad2ee231adc87e72593d03a0004b68c17771f7a412R154-R173) [[2]](diffhunk://#diff-4f206759c961f544a48464ad2ee231adc87e72593d03a0004b68c17771f7a412R208-R226)

**Input Handling Enhancements:**

* Added support for editing boolean and string array fields in the inbox item input: booleans now render as radio buttons, and string arrays use the new `TagInput` component. The input update logic was refactored to handle single values, arrays, and batch updates robustly. [[1]](diffhunk://#diff-1c13b4c8a3807b2138695399afcaedf0ddc12963bf573746e8714ab27e6e77ecL270-L284) [[2]](diffhunk://#diff-1c13b4c8a3807b2138695399afcaedf0ddc12963bf573746e8714ab27e6e77ecL349-R421) [[3]](diffhunk://#diff-1c13b4c8a3807b2138695399afcaedf0ddc12963bf573746e8714ab27e6e77ecL366-R445) [[4]](diffhunk://#diff-1c13b4c8a3807b2138695399afcaedf0ddc12963bf573746e8714ab27e6e77ecR485-R489)
* Switched textareas to use autosizing (`react-textarea-autosize`), improving vertical sizing and user experience for longer responses. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R84) [[2]](diffhunk://#diff-1c13b4c8a3807b2138695399afcaedf0ddc12963bf573746e8714ab27e6e77ecL139-R141) [[3]](diffhunk://#diff-1c13b4c8a3807b2138695399afcaedf0ddc12963bf573746e8714ab27e6e77ecL299-R366)

**Agent Inbox Polling and Settings:**

* Implemented auto-refresh (polling) for inbox threads, with a new `autoRefreshEnabled` state and a toggle in the settings popover. The polling interval is set to 15 seconds and respects the loading state to avoid overlapping fetches. [[1]](diffhunk://#diff-a30d2b3cc54b1f0b4ede17268bea59b3497ad575f8afe31774594bbb742a8b8dR39-R42) [[2]](diffhunk://#diff-a30d2b3cc54b1f0b4ede17268bea59b3497ad575f8afe31774594bbb742a8b8dR130-R134) [[3]](diffhunk://#diff-a30d2b3cc54b1f0b4ede17268bea59b3497ad575f8afe31774594bbb742a8b8dR319-R357) [[4]](diffhunk://#diff-e2580c5fdcda713fa7d5f22fe1dc54b7b96e3feb78defa9af85128db89bc822eL30-R31) [[5]](diffhunk://#diff-e2580c5fdcda713fa7d5f22fe1dc54b7b96e3feb78defa9af85128db89bc822eR55-R58) [[6]](diffhunk://#diff-e2580c5fdcda713fa7d5f22fe1dc54b7b96e3feb78defa9af85128db89bc822eR155-R172) [[7]](diffhunk://#diff-a30d2b3cc54b1f0b4ede17268bea59b3497ad575f8afe31774594bbb742a8b8dR523-R525)

**Documentation:**

* Updated the `README.md` to include instructions for starting the web server with `yarn dev`.