### PR TITLE
feat: add analytics tracking for interrupt events

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import "./globals.css";
 import { Inter } from "next/font/google";
 import { Toaster } from "@/components/ui/toaster";
 import { ThreadsProvider } from "@/components/agent-inbox/contexts/ThreadContext";
+import { AnalyticsProvider } from "@/components/agent-inbox/analytics/AnalyticsContext";
 import React from "react";
 import { SidebarProvider } from "@/components/ui/sidebar";
 import { AppSidebar, AppSidebarTrigger } from "@/components/app-sidebar";
@@ -31,6 +32,7 @@ export default function RootLayout({
         <React.Suspense fallback={<div>Loading (layout)...</div>}>
           <Toaster />
           <ThreadsProvider>
+            <AnalyticsProvider>
             <SidebarProvider>
               <AppSidebar />
               <main className="flex flex-row w-full min-h-full pt-6 pl-6 gap-6">
@@ -48,6 +50,7 @@ export default function RootLayout({
                 </div>
               </main>
             </SidebarProvider>
+            </AnalyticsProvider>
           </ThreadsProvider>
         </React.Suspense>
       </body>

--- a/src/components/agent-inbox/analytics/AnalyticsContext.tsx
+++ b/src/components/agent-inbox/analytics/AnalyticsContext.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import React from "react";
+import type {
+  AnalyticsBackend,
+  AnalyticsEvent,
+  AnalyticsEventCounts,
+  AnalyticsEventType,
+} from "./types";
+import { localStorageBackend } from "./local-storage-backend";
+
+interface AnalyticsContextValue {
+  trackEvent: (type: AnalyticsEventType, threadId: string) => void;
+  getEvents: () => AnalyticsEvent[];
+  getEventCounts: () => AnalyticsEventCounts;
+  clearEvents: () => void;
+}
+
+const AnalyticsContext = React.createContext<AnalyticsContextValue | undefined>(
+  undefined,
+);
+
+export function AnalyticsProvider({
+  children,
+  backend = localStorageBackend,
+}: {
+  children: React.ReactNode;
+  backend?: AnalyticsBackend;
+}) {
+  const trackEvent = React.useCallback(
+    (type: AnalyticsEventType, threadId: string) => {
+      backend.saveEvent({ type, threadId, timestamp: Date.now() });
+    },
+    [backend],
+  );
+
+  const getEvents = React.useCallback(() => backend.getEvents(), [backend]);
+
+  const getEventCounts = React.useCallback(
+    () => backend.getEventCounts(),
+    [backend],
+  );
+
+  const clearEvents = React.useCallback(() => backend.clearEvents(), [backend]);
+
+  const contextValue: AnalyticsContextValue = React.useMemo(
+    () => ({ trackEvent, getEvents, getEventCounts, clearEvents }),
+    [trackEvent, getEvents, getEventCounts, clearEvents],
+  );
+
+  return (
+    <AnalyticsContext.Provider value={contextValue}>
+      {children}
+    </AnalyticsContext.Provider>
+  );
+}
+
+export function useAnalytics() {
+  const context = React.useContext(AnalyticsContext);
+  if (context === undefined) {
+    throw new Error("useAnalytics must be used within an AnalyticsProvider");
+  }
+  return context;
+}

--- a/src/components/agent-inbox/analytics/local-storage-backend.ts
+++ b/src/components/agent-inbox/analytics/local-storage-backend.ts
@@ -1,0 +1,55 @@
+import { ANALYTICS_EVENTS_LOCAL_STORAGE_KEY } from "../constants";
+import type {
+  AnalyticsBackend,
+  AnalyticsEvent,
+  AnalyticsEventCounts,
+  AnalyticsEventType,
+} from "./types";
+
+const ALL_EVENT_TYPES: AnalyticsEventType[] = [
+  "accept",
+  "edit",
+  "response",
+  "ignore",
+  "resolve",
+];
+
+const emptyCounts = (): AnalyticsEventCounts =>
+  Object.fromEntries(ALL_EVENT_TYPES.map((t) => [t, 0])) as AnalyticsEventCounts;
+
+export const localStorageBackend: AnalyticsBackend = {
+  saveEvent(event: AnalyticsEvent): void {
+    if (typeof window === "undefined") return;
+    const events = this.getEvents();
+    events.push(event);
+    localStorage.setItem(
+      ANALYTICS_EVENTS_LOCAL_STORAGE_KEY,
+      JSON.stringify(events),
+    );
+  },
+
+  getEvents(): AnalyticsEvent[] {
+    if (typeof window === "undefined") return [];
+    try {
+      const raw = localStorage.getItem(ANALYTICS_EVENTS_LOCAL_STORAGE_KEY);
+      return raw ? (JSON.parse(raw) as AnalyticsEvent[]) : [];
+    } catch {
+      return [];
+    }
+  },
+
+  getEventCounts(): AnalyticsEventCounts {
+    const counts = emptyCounts();
+    for (const event of this.getEvents()) {
+      if (event.type in counts) {
+        counts[event.type]++;
+      }
+    }
+    return counts;
+  },
+
+  clearEvents(): void {
+    if (typeof window === "undefined") return;
+    localStorage.removeItem(ANALYTICS_EVENTS_LOCAL_STORAGE_KEY);
+  },
+};

--- a/src/components/agent-inbox/analytics/types.ts
+++ b/src/components/agent-inbox/analytics/types.ts
@@ -1,0 +1,21 @@
+export type AnalyticsEventType =
+  | "accept"
+  | "edit"
+  | "response"
+  | "ignore"
+  | "resolve";
+
+export interface AnalyticsEvent {
+  type: AnalyticsEventType;
+  threadId: string;
+  timestamp: number;
+}
+
+export type AnalyticsEventCounts = Record<AnalyticsEventType, number>;
+
+export interface AnalyticsBackend {
+  saveEvent(event: AnalyticsEvent): void;
+  getEvents(): AnalyticsEvent[];
+  getEventCounts(): AnalyticsEventCounts;
+  clearEvents(): void;
+}

--- a/src/components/agent-inbox/components/analytics-popover.tsx
+++ b/src/components/agent-inbox/components/analytics-popover.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { BarChart3 } from "lucide-react";
+import React from "react";
+import { PillButton } from "@/components/ui/pill-button";
+import { Button } from "@/components/ui/button";
+import { useAnalytics } from "../analytics/AnalyticsContext";
+import type { AnalyticsEventCounts } from "../analytics/types";
+
+const EVENT_LABELS: Record<keyof AnalyticsEventCounts, string> = {
+  accept: "Accepted",
+  edit: "Edited",
+  response: "Responded",
+  ignore: "Ignored",
+  resolve: "Resolved",
+};
+
+export function AnalyticsPopover() {
+  const { getEventCounts, clearEvents } = useAnalytics();
+  const [counts, setCounts] = React.useState<AnalyticsEventCounts | null>(null);
+
+  const refreshCounts = React.useCallback(() => {
+    setCounts(getEventCounts());
+  }, [getEventCounts]);
+
+  const handleClear = () => {
+    clearEvents();
+    refreshCounts();
+  };
+
+  const total = counts
+    ? Object.values(counts).reduce((sum, n) => sum + n, 0)
+    : 0;
+
+  return (
+    <Popover
+      onOpenChange={(open) => {
+        if (open) refreshCounts();
+      }}
+    >
+      <PopoverTrigger asChild>
+        <PillButton
+          variant="outline"
+          className="flex gap-2 items-center justify-center text-gray-800 w-fit"
+          size="lg"
+        >
+          <BarChart3 />
+          <span>Analytics</span>
+        </PillButton>
+      </PopoverTrigger>
+      <PopoverContent className="w-72">
+        <div className="grid gap-4">
+          <div className="space-y-2">
+            <h4 className="font-medium leading-none">Analytics</h4>
+            <p className="text-sm text-muted-foreground">
+              Interrupt event counts
+            </p>
+          </div>
+          {counts && (
+            <div className="flex flex-col gap-2">
+              {(
+                Object.entries(EVENT_LABELS) as [
+                  keyof AnalyticsEventCounts,
+                  string,
+                ][]
+              ).map(([type, label]) => (
+                <div
+                  key={type}
+                  className="flex items-center justify-between text-sm"
+                >
+                  <span className="text-muted-foreground">{label}</span>
+                  <span className="font-mono font-medium">{counts[type]}</span>
+                </div>
+              ))}
+              <div className="flex items-center justify-between text-sm border-t pt-2 mt-1">
+                <span className="font-medium">Total</span>
+                <span className="font-mono font-medium">{total}</span>
+              </div>
+            </div>
+          )}
+          <Button variant="outline" size="sm" onClick={handleClear}>
+            Clear Data
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/components/agent-inbox/constants.ts
+++ b/src/components/agent-inbox/constants.ts
@@ -9,5 +9,6 @@ export const NO_INBOXES_FOUND_PARAM = "no_inboxes_found";
 export const AGENT_INBOX_GITHUB_README_URL =
   "https://github.com/langchain-ai/agent-inbox/blob/main/README.md";
 
+export const ANALYTICS_EVENTS_LOCAL_STORAGE_KEY = "inbox:analytics_events";
 export const IMPROPER_SCHEMA = "improper_schema";
 export const STUDIO_NOT_WORKING_TROUBLESHOOTING_URL = `${AGENT_INBOX_GITHUB_README_URL}#the-open-in-studio-button-doesnt-work-for-my-deployed-graphs`;

--- a/src/components/agent-inbox/hooks/use-interrupted-actions.tsx
+++ b/src/components/agent-inbox/hooks/use-interrupted-actions.tsx
@@ -12,6 +12,7 @@ import { useThreadsContext } from "../contexts/ThreadContext";
 import { createDefaultHumanResponse } from "../utils";
 import { INBOX_PARAM, VIEW_STATE_THREAD_QUERY_PARAM } from "../constants";
 import { useQueryParams } from "./use-query-params";
+import { useAnalytics } from "../analytics/AnalyticsContext";
 import { logger } from "../utils/logger";
 
 interface UseInterruptedActionsInput<
@@ -75,6 +76,7 @@ export default function useInterruptedActions<
   const { updateQueryParams, getSearchParam } = useQueryParams();
   const { fetchSingleThread, fetchThreads, sendHumanResponse, ignoreThread } =
     useThreadsContext<ThreadValues>();
+  const { trackEvent } = useAnalytics();
 
   const [humanResponse, setHumanResponse] = React.useState<
     HumanResponseWithEdits[]
@@ -285,6 +287,9 @@ export default function useInterruptedActions<
       }
 
       if (!errorOccurred) {
+        if (selectedSubmitType) {
+          trackEvent(selectedSubmitType, threadData.thread.thread_id);
+        }
         setCurrentNode("");
         setStreaming(false);
         const updatedThreadData = await fetchSingleThread(
@@ -350,6 +355,7 @@ export default function useInterruptedActions<
 
     await sendHumanResponse(threadData.thread.thread_id, [ignoreResponse]);
     await fetchThreads(currentInbox);
+    trackEvent("ignore", threadData.thread.thread_id);
 
     setLoading(false);
     toast({
@@ -389,6 +395,7 @@ export default function useInterruptedActions<
 
     await ignoreThread(threadData.thread.thread_id);
     await fetchThreads(currentInbox);
+    trackEvent("resolve", threadData.thread.thread_id);
 
     setLoading(false);
     updateQueryParams(VIEW_STATE_THREAD_QUERY_PARAM);

--- a/src/components/app-sidebar/index.tsx
+++ b/src/components/app-sidebar/index.tsx
@@ -13,6 +13,7 @@ import {
 import { FileText, UploadCloud, House } from "lucide-react";
 import { agentInboxSvg } from "../agent-inbox/components/agent-inbox-logo";
 import { SettingsPopover } from "../agent-inbox/components/settings-popover";
+import { AnalyticsPopover } from "../agent-inbox/components/analytics-popover";
 import { PillButton } from "../ui/pill-button";
 import React from "react";
 import { useSidebar } from "@/components/ui/sidebar";
@@ -129,6 +130,7 @@ export function AppSidebar() {
 
               <div className="flex flex-col gap-3 pl-7">
                 <SettingsPopover />
+                <AnalyticsPopover />
                 <NextLink
                   href={AGENT_INBOX_GITHUB_README_URL}
                   target="_blank"


### PR DESCRIPTION
## Summary
- Adds a modular analytics system to track interrupt event actions (accept, edit, response, ignore, resolve)
- Uses a swappable `AnalyticsBackend` interface with a `localStorage` default implementation, easily replaceable with an API backend later
- Adds an Analytics popover in the sidebar showing per-type event counts with a "Clear Data" button

## Files changed
**New files (4):**
- `src/components/agent-inbox/analytics/types.ts` — type definitions and backend interface
- `src/components/agent-inbox/analytics/local-storage-backend.ts` — localStorage implementation (SSR-safe)
- `src/components/agent-inbox/analytics/AnalyticsContext.tsx` — React Context/Provider + `useAnalytics()` hook
- `src/components/agent-inbox/components/analytics-popover.tsx` — sidebar popover UI

**Modified files (4):**
- `src/components/agent-inbox/constants.ts` — added localStorage key
- `src/app/layout.tsx` — mounted `AnalyticsProvider`
- `src/components/agent-inbox/hooks/use-interrupted-actions.tsx` — instrumented `handleSubmit`, `handleIgnore`, `handleResolve` with `trackEvent` calls
- `src/components/app-sidebar/index.tsx` — added `AnalyticsPopover` to sidebar

## Test plan
- [ ] Trigger accept/edit/response on interrupted threads and verify counts increment in the Analytics popover
- [ ] Trigger ignore on a thread and verify the "Ignored" count increments
- [ ] Trigger resolve on a thread and verify the "Resolved" count increments
- [ ] Click "Clear Data" and verify all counts reset to 0
- [ ] Refresh the page and verify counts persist (localStorage)
- [ ] Run `npm run build` — passes with no new errors

Closes #22