### PR TITLE
feat: show error when deployment URL is unreachable

### DIFF
--- a/src/components/agent-inbox/components/add-agent-inbox-dialog.tsx
+++ b/src/components/agent-inbox/components/add-agent-inbox-dialog.tsx
@@ -20,7 +20,7 @@ import {
   LANGCHAIN_API_KEY_LOCAL_STORAGE_KEY,
 } from "../constants";
 import { PasswordInput } from "@/components/ui/password-input";
-import { isDeployedUrl, fetchDeploymentInfo } from "../utils";
+import { isDeployedUrl, fetchDeploymentInfo, verifyDeploymentUrl } from "../utils";
 import { useLocalStorage } from "../hooks/use-local-storage";
 import { LoaderCircle } from "lucide-react";
 import { logger } from "../utils/logger";
@@ -72,6 +72,17 @@ export function AddAgentInboxDialog({
     setErrorMessage(null);
 
     try {
+      // Verify the deployment URL is reachable before proceeding
+      const connectionCheck = await verifyDeploymentUrl(deploymentUrl);
+      if (!connectionCheck.reachable) {
+        setErrorMessage(
+          connectionCheck.error ||
+            "Could not connect to the deployment URL. Make sure the server is running."
+        );
+        setIsSubmitting(false);
+        return;
+      }
+
       const isDeployed = isDeployedUrl(deploymentUrl);
       let inboxId = uuidv4();
       let fetchedTenantId: string | undefined | null = undefined;

--- a/src/components/agent-inbox/contexts/ThreadContext.tsx
+++ b/src/components/agent-inbox/contexts/ThreadContext.tsx
@@ -300,6 +300,13 @@ export function ThreadsProvider<
         setHasMoreThreads(threads.length === limit);
       } catch (e) {
         logger.error("Failed to fetch threads", e);
+        toast({
+          title: "Connection failed",
+          description:
+            "Could not reach the deployment URL. Make sure the server is running.",
+          variant: "destructive",
+          duration: 5000,
+        });
       }
       setLoading(false);
     },


### PR DESCRIPTION
## Summary
- Adds a reusable `verifyDeploymentUrl()` utility in `utils.ts` that pings the `/info` endpoint with a configurable timeout (default 5s) and returns a structured `{ reachable, error? }` result
- Uses it in the add-inbox dialog to **block adding unreachable URLs** (both localhost and deployed) with an inline error message
- Shows a **destructive toast** in `ThreadContext` when thread fetching fails against a previously added inbox

## Files changed
- `src/components/agent-inbox/utils.ts` — new `verifyDeploymentUrl()` function
- `src/components/agent-inbox/components/add-agent-inbox-dialog.tsx` — connection check before adding inbox
- `src/components/agent-inbox/contexts/ThreadContext.tsx` — toast on fetch failure

## Test plan
- [ ] Add an inbox with a localhost URL when no local server is running — should show inline error immediately
- [ ] Add an inbox with an invalid deployed URL — should show inline error immediately
- [ ] Add an inbox with a valid, running URL — should succeed as before
- [ ] Stop a previously running server, refresh the page — should show a destructive toast

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)