### PR TITLE
fix: prevent welcome dialog from re-opening after adding first inbox

### DIFF
--- a/src/components/agent-inbox/components/add-agent-inbox-dialog.tsx
+++ b/src/components/agent-inbox/components/add-agent-inbox-dialog.tsx
@@ -147,15 +147,18 @@ export function AddAgentInboxDialog({
         description: "Agent inbox added successfully",
         duration: 3000,
       });
-      updateQueryParams(NO_INBOXES_FOUND_PARAM);
 
       setGraphId("");
       setDeploymentUrl("");
       setName("");
       setOpen(false);
 
-      // Force page reload to ensure the new inbox appears
-      window.location.reload();
+      // Build a clean URL without the no_inboxes_found param
+      // This avoids the race condition where window.location.reload()
+      // fires before async router.replace() can remove the param
+      const url = new URL(window.location.href);
+      url.searchParams.delete(NO_INBOXES_FOUND_PARAM);
+      window.location.href = url.toString();
     } catch (error) {
       logger.error("Error adding agent inbox:", error);
       setErrorMessage(

--- a/src/components/agent-inbox/hooks/use-inboxes.tsx
+++ b/src/components/agent-inbox/hooks/use-inboxes.tsx
@@ -121,6 +121,15 @@ export function useInboxes() {
         return;
       }
 
+      // Inboxes exist — ensure the no_inboxes_found param is removed
+      // This acts as a safety net in case the param persists after a reload
+      const currentNoInboxesParam = new URLSearchParams(
+        window.location.search
+      ).get(NO_INBOXES_FOUND_PARAM);
+      if (currentNoInboxesParam) {
+        updateQueryParams(NO_INBOXES_FOUND_PARAM);
+      }
+
       // Ensure each agent inbox has an ID, and if not, add one
       currentInboxes = currentInboxes.map((inbox) => {
         return {
@@ -233,10 +242,16 @@ export function useInboxes() {
       if (!agentInboxesStr || agentInboxesStr === "[]") {
         setAgentInboxes([newInbox]);
         setItem(AGENT_INBOXES_LOCAL_STORAGE_KEY, JSON.stringify([newInbox]));
-        // Set agent inbox, offset, and limit
+        // Set agent inbox, offset, and limit, and remove no_inboxes_found param
         updateQueryParams(
-          [AGENT_INBOX_PARAM, OFFSET_PARAM, LIMIT_PARAM, INBOX_PARAM],
-          [newInbox.id, "0", "10", "interrupted"]
+          [
+            AGENT_INBOX_PARAM,
+            OFFSET_PARAM,
+            LIMIT_PARAM,
+            INBOX_PARAM,
+            NO_INBOXES_FOUND_PARAM,
+          ],
+          [newInbox.id, "0", "10", "interrupted", ""]
         );
         return;
       }


### PR DESCRIPTION
## Summary
- Fixes a race condition where `window.location.reload()` fired before async `router.replace()` could remove the `no_inboxes_found` query param, causing the welcome dialog to re-open after adding the first inbox
- Replaces `window.location.reload()` with synchronous URL construction that strips `no_inboxes_found` before navigating
- Removes `no_inboxes_found` param in `addAgentInbox` when adding to an empty inbox list
- Adds a safety net in `getAgentInboxes` to clean up the param when inboxes exist but the param persists

## Files Changed
- `src/components/agent-inbox/components/add-agent-inbox-dialog.tsx` — replaced `window.location.reload()` with clean URL navigation
- `src/components/agent-inbox/hooks/use-inboxes.tsx` — remove `no_inboxes_found` param when adding first inbox + safety net cleanup

## Test Plan
- [x] Clear localStorage, reload page → welcome dialog appears
- [x] Fill in form and click "Add Inbox" → dialog closes, page reloads
- [x] After reload, welcome dialog does **not** re-appear
- [x] URL no longer contains `no_inboxes_found=true` after adding inbox
- [x] Lint passes with no new warnings
- [x] Build passes successfully

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)