### PR TITLE
feat: add keyboard shortcuts for thread view (#65)

### DIFF
--- a/src/components/agent-inbox/components/inbox-item-input.tsx
+++ b/src/components/agent-inbox/components/inbox-item-input.tsx
@@ -14,6 +14,7 @@ import { Button } from "@/components/ui/button";
 import { CircleX, LoaderCircle, Undo2 } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { logger } from "../utils/logger";
+import { HUMAN_RESPONSE_HOTKEY_TARGET } from "../hooks/use-thread-keyboard-shortcuts";
 
 function ResetButton({ handleReset }: { handleReset: () => void }) {
   return (
@@ -138,6 +139,7 @@ function ResponseComponent({
           onKeyDown={handleKeyDown}
           rows={4}
           placeholder="Your response here..."
+          data-hotkey-target={HUMAN_RESPONSE_HOTKEY_TARGET}
         />
       </div>
 
@@ -297,6 +299,9 @@ function EditAndOrAcceptComponent({
                 onChange={(e) => onEditChange(e.target.value, editResponse, k)}
                 onKeyDown={handleKeyDown}
                 rows={numRows}
+                {...(idx === 0
+                  ? { "data-hotkey-target": HUMAN_RESPONSE_HOTKEY_TARGET }
+                  : {})}
               />
             </div>
           </div>

--- a/src/components/agent-inbox/components/inbox-item-input.tsx
+++ b/src/components/agent-inbox/components/inbox-item-input.tsx
@@ -14,7 +14,7 @@ import { Button } from "@/components/ui/button";
 import { CircleX, LoaderCircle, Undo2 } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { logger } from "../utils/logger";
-import { HUMAN_RESPONSE_HOTKEY_TARGET } from "../hooks/use-thread-keyboard-shortcuts";
+import { HUMAN_RESPONSE_HOTKEY_TARGET } from "../constants";
 
 function ResetButton({ handleReset }: { handleReset: () => void }) {
   return (
@@ -299,9 +299,9 @@ function EditAndOrAcceptComponent({
                 onChange={(e) => onEditChange(e.target.value, editResponse, k)}
                 onKeyDown={handleKeyDown}
                 rows={numRows}
-                {...(idx === 0
-                  ? { "data-hotkey-target": HUMAN_RESPONSE_HOTKEY_TARGET }
-                  : {})}
+                data-hotkey-target={
+                  idx === 0 ? HUMAN_RESPONSE_HOTKEY_TARGET : undefined
+                }
               />
             </div>
           </div>

--- a/src/components/agent-inbox/components/thread-actions-view.tsx
+++ b/src/components/agent-inbox/components/thread-actions-view.tsx
@@ -9,6 +9,7 @@ import {
 } from "lucide-react";
 import { ThreadData, GenericThreadData } from "../types";
 import useInterruptedActions from "../hooks/use-interrupted-actions";
+import { useThreadKeyboardShortcuts } from "../hooks/use-thread-keyboard-shortcuts";
 import { constructOpenInStudioURL } from "../utils";
 import { ThreadIdCopyable } from "./thread-id";
 import { InboxItemInput } from "./inbox-item-input";
@@ -140,6 +141,12 @@ export function ThreadActionsView<
         }
       : null,
     setThreadData,
+  });
+
+  useThreadKeyboardShortcuts({
+    threadId: threadData.thread.thread_id,
+    isInterrupted,
+    onResetAllInputs: actions.handleResetAllInputs,
   });
 
   const handleOpenInStudio = () => {

--- a/src/components/agent-inbox/constants.ts
+++ b/src/components/agent-inbox/constants.ts
@@ -11,3 +11,6 @@ export const AGENT_INBOX_GITHUB_README_URL =
 
 export const IMPROPER_SCHEMA = "improper_schema";
 export const STUDIO_NOT_WORKING_TROUBLESHOOTING_URL = `${AGENT_INBOX_GITHUB_README_URL}#the-open-in-studio-button-doesnt-work-for-my-deployed-graphs`;
+
+/** `data-hotkey-target` value for the primary human response / edit textarea. */
+export const HUMAN_RESPONSE_HOTKEY_TARGET = "human-response";

--- a/src/components/agent-inbox/hooks/use-interrupted-actions.tsx
+++ b/src/components/agent-inbox/hooks/use-interrupted-actions.tsx
@@ -59,7 +59,7 @@ interface UseInterruptedActionsValue {
   setHasAddedResponse: React.Dispatch<React.SetStateAction<boolean>>;
   setHasEdited: React.Dispatch<React.SetStateAction<boolean>>;
 
-  /** Reset all human response / edit inputs to their initial values (`u` hotkey). */
+  /** Reset all human response / edit inputs to their initial values. */
   handleResetAllInputs: () => void;
 
   // Refs
@@ -397,12 +397,14 @@ export default function useInterruptedActions<
   const handleResetAllInputs = React.useCallback(() => {
     if (!threadData?.interrupts?.length) return;
     try {
-      const { responses, defaultSubmitType } = createDefaultHumanResponse(
-        threadData.interrupts,
-        initialHumanInterruptEditValue
-      );
+      const { responses, defaultSubmitType, hasAccept } =
+        createDefaultHumanResponse(
+          threadData.interrupts,
+          initialHumanInterruptEditValue
+        );
       setHumanResponse(responses);
       setSelectedSubmitType(defaultSubmitType);
+      setAcceptAllowed(hasAccept);
       setHasEdited(false);
       setHasAddedResponse(false);
     } catch (e) {

--- a/src/components/agent-inbox/hooks/use-interrupted-actions.tsx
+++ b/src/components/agent-inbox/hooks/use-interrupted-actions.tsx
@@ -59,6 +59,9 @@ interface UseInterruptedActionsValue {
   setHasAddedResponse: React.Dispatch<React.SetStateAction<boolean>>;
   setHasEdited: React.Dispatch<React.SetStateAction<boolean>>;
 
+  /** Reset all human response / edit inputs to their initial values (`u` hotkey). */
+  handleResetAllInputs: () => void;
+
   // Refs
   initialHumanInterruptEditValue: React.MutableRefObject<
     Record<string, string>
@@ -391,10 +394,27 @@ export default function useInterruptedActions<
     updateQueryParams(VIEW_STATE_THREAD_QUERY_PARAM);
   };
 
+  const handleResetAllInputs = React.useCallback(() => {
+    if (!threadData?.interrupts?.length) return;
+    try {
+      const { responses, defaultSubmitType } = createDefaultHumanResponse(
+        threadData.interrupts,
+        initialHumanInterruptEditValue
+      );
+      setHumanResponse(responses);
+      setSelectedSubmitType(defaultSubmitType);
+      setHasEdited(false);
+      setHasAddedResponse(false);
+    } catch (e) {
+      logger.error("Error resetting human response inputs", e);
+    }
+  }, [threadData?.interrupts]);
+
   return {
     handleSubmit,
     handleIgnore,
     handleResolve,
+    handleResetAllInputs,
     streaming,
     streamFinished,
     currentNode,

--- a/src/components/agent-inbox/hooks/use-thread-keyboard-shortcuts.tsx
+++ b/src/components/agent-inbox/hooks/use-thread-keyboard-shortcuts.tsx
@@ -1,15 +1,17 @@
-import React from "react";
+import { useEffect } from "react";
 import { useQueryParams } from "./use-query-params";
 import { useThreadsContext } from "../contexts/ThreadContext";
-import { INBOX_PARAM, VIEW_STATE_THREAD_QUERY_PARAM } from "../constants";
+import {
+  HUMAN_RESPONSE_HOTKEY_TARGET,
+  INBOX_PARAM,
+  VIEW_STATE_THREAD_QUERY_PARAM,
+} from "../constants";
 import { ThreadStatusWithAll } from "../types";
 import { isTypingTarget } from "../utils/keyboard";
 import {
   filterThreadsForInbox,
   getAdjacentThreadId,
 } from "../utils/thread-list";
-
-export const HUMAN_RESPONSE_HOTKEY_TARGET = "human-response";
 
 interface UseThreadKeyboardShortcutsOptions {
   threadId: string;
@@ -19,54 +21,55 @@ interface UseThreadKeyboardShortcutsOptions {
 }
 
 /**
- * Thread-detail hotkeys (issue #65):
+ * Thread-detail hotkeys:
  * - `e` — close thread / back to inbox list
  * - ArrowUp / ArrowDown — previous / next thread in the current inbox page
  * - `r` — focus human response / edit input
- * - `u` — undo / reset all human response inputs
+ * - `u` — reset all human response inputs
  */
 export function useThreadKeyboardShortcuts({
   threadId,
   isInterrupted,
   onResetAllInputs,
 }: UseThreadKeyboardShortcutsOptions) {
-  const { updateQueryParams, getSearchParam } = useQueryParams();
+  const { updateQueryParams } = useQueryParams();
   const { threadData } = useThreadsContext();
 
-  React.useEffect(() => {
+  useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.metaKey || event.ctrlKey || event.altKey) return;
+      // Do not intercept keys while the user is typing in a field.
+      if (isTypingTarget(event.target)) return;
 
-      const inbox = (getSearchParam(INBOX_PARAM) ||
-        "interrupted") as ThreadStatusWithAll;
+      const inboxParam =
+        typeof window !== "undefined"
+          ? new URLSearchParams(window.location.search).get(INBOX_PARAM)
+          : null;
+      const inbox = (inboxParam || "interrupted") as ThreadStatusWithAll;
       const filtered = filterThreadsForInbox(threadData, inbox);
+      const key = event.key.length === 1 ? event.key.toLowerCase() : event.key;
 
-      switch (event.key) {
-        case "e":
-        case "E": {
-          if (isTypingTarget(event.target)) return;
+      switch (key) {
+        case "e": {
           event.preventDefault();
           updateQueryParams(VIEW_STATE_THREAD_QUERY_PARAM);
           break;
         }
         case "ArrowUp":
         case "ArrowDown": {
-          if (isTypingTarget(event.target)) return;
           event.preventDefault();
           const nextId = getAdjacentThreadId(
             filtered,
             threadId,
-            event.key === "ArrowUp" ? "prev" : "next"
+            key === "ArrowUp" ? "prev" : "next"
           );
           if (nextId) {
             updateQueryParams(VIEW_STATE_THREAD_QUERY_PARAM, nextId);
           }
           break;
         }
-        case "r":
-        case "R": {
+        case "r": {
           if (!isInterrupted) return;
-          // Allow focusing even when already in an input (Superhuman-style).
           event.preventDefault();
           const el = document.querySelector<HTMLTextAreaElement>(
             `textarea[data-hotkey-target="${HUMAN_RESPONSE_HOTKEY_TARGET}"]`
@@ -74,8 +77,7 @@ export function useThreadKeyboardShortcuts({
           el?.focus();
           break;
         }
-        case "u":
-        case "U": {
+        case "u": {
           if (!isInterrupted || !onResetAllInputs) return;
           event.preventDefault();
           onResetAllInputs();
@@ -93,7 +95,6 @@ export function useThreadKeyboardShortcuts({
     threadData,
     isInterrupted,
     onResetAllInputs,
-    getSearchParam,
     updateQueryParams,
   ]);
 }

--- a/src/components/agent-inbox/hooks/use-thread-keyboard-shortcuts.tsx
+++ b/src/components/agent-inbox/hooks/use-thread-keyboard-shortcuts.tsx
@@ -1,0 +1,99 @@
+import React from "react";
+import { useQueryParams } from "./use-query-params";
+import { useThreadsContext } from "../contexts/ThreadContext";
+import { INBOX_PARAM, VIEW_STATE_THREAD_QUERY_PARAM } from "../constants";
+import { ThreadStatusWithAll } from "../types";
+import { isTypingTarget } from "../utils/keyboard";
+import {
+  filterThreadsForInbox,
+  getAdjacentThreadId,
+} from "../utils/thread-list";
+
+export const HUMAN_RESPONSE_HOTKEY_TARGET = "human-response";
+
+interface UseThreadKeyboardShortcutsOptions {
+  threadId: string;
+  /** When true, `r` focuses the human response input and `u` resets inputs. */
+  isInterrupted: boolean;
+  onResetAllInputs?: () => void;
+}
+
+/**
+ * Thread-detail hotkeys (issue #65):
+ * - `e` — close thread / back to inbox list
+ * - ArrowUp / ArrowDown — previous / next thread in the current inbox page
+ * - `r` — focus human response / edit input
+ * - `u` — undo / reset all human response inputs
+ */
+export function useThreadKeyboardShortcuts({
+  threadId,
+  isInterrupted,
+  onResetAllInputs,
+}: UseThreadKeyboardShortcutsOptions) {
+  const { updateQueryParams, getSearchParam } = useQueryParams();
+  const { threadData } = useThreadsContext();
+
+  React.useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.metaKey || event.ctrlKey || event.altKey) return;
+
+      const inbox = (getSearchParam(INBOX_PARAM) ||
+        "interrupted") as ThreadStatusWithAll;
+      const filtered = filterThreadsForInbox(threadData, inbox);
+
+      switch (event.key) {
+        case "e":
+        case "E": {
+          if (isTypingTarget(event.target)) return;
+          event.preventDefault();
+          updateQueryParams(VIEW_STATE_THREAD_QUERY_PARAM);
+          break;
+        }
+        case "ArrowUp":
+        case "ArrowDown": {
+          if (isTypingTarget(event.target)) return;
+          event.preventDefault();
+          const nextId = getAdjacentThreadId(
+            filtered,
+            threadId,
+            event.key === "ArrowUp" ? "prev" : "next"
+          );
+          if (nextId) {
+            updateQueryParams(VIEW_STATE_THREAD_QUERY_PARAM, nextId);
+          }
+          break;
+        }
+        case "r":
+        case "R": {
+          if (!isInterrupted) return;
+          // Allow focusing even when already in an input (Superhuman-style).
+          event.preventDefault();
+          const el = document.querySelector<HTMLTextAreaElement>(
+            `textarea[data-hotkey-target="${HUMAN_RESPONSE_HOTKEY_TARGET}"]`
+          );
+          el?.focus();
+          break;
+        }
+        case "u":
+        case "U": {
+          if (!isInterrupted || !onResetAllInputs) return;
+          event.preventDefault();
+          onResetAllInputs();
+          break;
+        }
+        default:
+          break;
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [
+    threadId,
+    threadData,
+    isInterrupted,
+    onResetAllInputs,
+    getSearchParam,
+    updateQueryParams,
+  ]);
+}

--- a/src/components/agent-inbox/inbox-view.tsx
+++ b/src/components/agent-inbox/inbox-view.tsx
@@ -10,6 +10,7 @@ import { InboxButtons } from "./components/inbox-buttons";
 import { BackfillBanner } from "./components/backfill-banner";
 import { forceInboxBackfill } from "./utils/backfill";
 import { logger } from "./utils/logger";
+import { filterThreadsForInbox } from "./utils/thread-list";
 
 interface AgentInboxViewProps<
   _ThreadValues extends Record<string, any> = Record<string, any>,
@@ -144,11 +145,7 @@ export function AgentInboxView<
   }, [searchParams]);
 
   const threadDataToRender = React.useMemo(
-    () =>
-      threadData.filter((t) => {
-        if (selectedInbox === "all") return true;
-        return t.status === selectedInbox;
-      }),
+    () => filterThreadsForInbox(threadData, selectedInbox),
     [selectedInbox, threadData]
   );
   const noThreadsFound = !threadDataToRender.length;

--- a/src/components/agent-inbox/utils/keyboard.ts
+++ b/src/components/agent-inbox/utils/keyboard.ts
@@ -1,0 +1,7 @@
+/** True when the event target is an editable field (avoid stealing typing keys). */
+export function isTypingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName;
+  if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return true;
+  return target.isContentEditable;
+}

--- a/src/components/agent-inbox/utils/thread-list.ts
+++ b/src/components/agent-inbox/utils/thread-list.ts
@@ -1,0 +1,28 @@
+import { ThreadData, ThreadStatusWithAll } from "../types";
+
+export function filterThreadsForInbox<
+  T extends Record<string, any> = Record<string, any>,
+>(
+  threadData: ThreadData<T>[],
+  selectedInbox: ThreadStatusWithAll
+): ThreadData<T>[] {
+  return threadData.filter((t) => {
+    if (selectedInbox === "all") return true;
+    return t.status === selectedInbox;
+  });
+}
+
+export function getAdjacentThreadId<
+  T extends Record<string, any> = Record<string, any>,
+>(
+  threads: ThreadData<T>[],
+  currentThreadId: string,
+  direction: "prev" | "next"
+): string | undefined {
+  const index = threads.findIndex(
+    (t) => t.thread.thread_id === currentThreadId
+  );
+  if (index === -1) return undefined;
+  const nextIndex = direction === "prev" ? index - 1 : index + 1;
+  return threads[nextIndex]?.thread.thread_id;
+}


### PR DESCRIPTION
## Summary
- Adds thread-detail hotkeys from #65: `e` (back to list), `ArrowUp`/`ArrowDown` (prev/next thread), `r` (focus human response input), `u` (reset all inputs)
- Shares inbox thread filtering via `filterThreadsForInbox` so arrow navigation matches the visible list
- Skips `e`/arrows while typing in inputs; `r`/`u` work on interrupted threads

## Test plan
- [ ] Open an interrupted thread
- [ ] Press `e` — returns to the inbox list
- [ ] Press `ArrowDown` / `ArrowUp` — moves to adjacent threads on the current page
- [ ] Press `r` — focuses the response/edit textarea
- [ ] Edit fields, then press `u` — inputs reset to initial values
- [ ] Type in a textarea and press `e` — key is ignored (no accidental close)

Closes #65