### PR TITLE
fix: resolve hydration error from nested <p> tags in welcome dialog

### DIFF
--- a/src/components/agent-inbox/components/add-agent-inbox-dialog.tsx
+++ b/src/components/agent-inbox/components/add-agent-inbox-dialog.tsx
@@ -193,8 +193,8 @@ export function AddAgentInboxDialog({
           <DialogHeader>
             <DialogTitle>Welcome to the Agent Inbox!</DialogTitle>
             <DialogDescription>
-              <p>To get started, please add an inbox below.</p>
-              <p>
+              <span className="block">To get started, please add an inbox below.</span>
+              <span className="block">
                 Not sure where to start? Check out our docs
                 <a
                   href={AGENT_INBOX_GITHUB_README_URL}
@@ -205,7 +205,7 @@ export function AddAgentInboxDialog({
                   here
                 </a>
                 .
-              </p>
+              </span>
             </DialogDescription>
           </DialogHeader>
         ) : (


### PR DESCRIPTION
## Summary

Fix React hydration error caused by nested `<p>` elements inside the `DialogDescription` component in `add-agent-inbox-dialog.tsx` (lines ~195-208). HTML does not allow `<p>` elements nested inside other `<p>` elements, which causes React hydration mismatches.

Replaces inner `<p>` tags with `<span>` elements styled as blocks to maintain the same visual appearance.

Related to #168.

## Testing

Verified the nested `<p>` pattern exists in the source file.